### PR TITLE
Update performance for farms and syrups

### DIFF
--- a/src/components/SyrupCard/SyrupCard.tsx
+++ b/src/components/SyrupCard/SyrupCard.tsx
@@ -4,7 +4,12 @@ import { makeStyles, useTheme } from '@material-ui/core/styles';
 import { SyrupInfo } from 'state/stake/hooks';
 import { unwrappedToken } from 'utils/wrappedCurrency';
 import { CurrencyLogo } from 'components';
-import { formatCompact, getDaysCurrentYear, returnTokenFromKey } from 'utils';
+import {
+  formatCompact,
+  getDaysCurrentYear,
+  getTokenAPRSyrup,
+  returnTokenFromKey,
+} from 'utils';
 import SyrupCardDetails from './SyrupCardDetails';
 
 const useStyles = makeStyles(({ palette, breakpoints }) => ({
@@ -38,32 +43,13 @@ const SyrupCard: React.FC<{ syrup: SyrupInfo }> = ({ syrup }) => {
     : `${syrup.totalStakedAmount.toSignificant(6, { groupSeparator: ',' }) ??
         '-'} ${syrup.stakingToken.symbol}`;
 
-  const tokenAPR = useMemo(
-    () =>
-      syrup.valueOfTotalStakedAmountInUSDC &&
-      syrup.valueOfTotalStakedAmountInUSDC > 0
-        ? (
-            ((syrup.rewards ?? 0) / syrup.valueOfTotalStakedAmountInUSDC) *
-            daysCurrentYear *
-            100
-          ).toLocaleString()
-        : 0,
-    [syrup?.valueOfTotalStakedAmountInUSDC, syrup?.rewards, daysCurrentYear],
-  );
-
   const dQUICKAPR = useMemo(
     () =>
       (((Number(syrup.oneDayVol) * 0.04 * 0.01) /
         Number(syrup.dQuickTotalSupply.toSignificant(6))) *
         daysCurrentYear) /
       (Number(syrup.dQUICKtoQUICK.toSignificant(6)) * Number(syrup.quickPrice)),
-    [
-      syrup?.oneDayVol,
-      syrup?.dQuickTotalSupply,
-      daysCurrentYear,
-      syrup?.dQUICKtoQUICK,
-      syrup?.quickPrice,
-    ],
+    [syrup, daysCurrentYear],
   );
 
   const dQUICKAPY = useMemo(
@@ -155,7 +141,7 @@ const SyrupCard: React.FC<{ syrup: SyrupInfo }> = ({ syrup }) => {
           )}
           <Box textAlign={isMobile ? 'right' : 'left'}>
             <Typography variant='body2' style={{ color: palette.success.main }}>
-              {tokenAPR}%
+              {getTokenAPRSyrup(syrup).toLocaleString()}%
             </Typography>
             {isDQUICKStakingToken && (
               <Box display='flex'>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -72,6 +72,8 @@ export const GlobalConst = {
     // the Uniswap Default token list lives here
     DEFAULT_TOKEN_LIST_URL:
       'https://unpkg.com/quickswap-default-token-list@1.2.20/build/quickswap-default.tokenlist.json',
+  },
+  farmIndex: {
     LPFARM_INDEX: 0,
     DUALFARM_INDEX: 1,
   },

--- a/src/pages/DragonPage/DragonPage.tsx
+++ b/src/pages/DragonPage/DragonPage.tsx
@@ -28,7 +28,12 @@ import DragonBg2 from 'assets/images/DragonBg2.svg';
 import DragonLairMask from 'assets/images/DragonLairMask.svg';
 import { ReactComponent as PriceExchangeIcon } from 'assets/images/PriceExchangeIcon.svg';
 import { ReactComponent as SearchIcon } from 'assets/images/SearchIcon.svg';
-import { getDaysCurrentYear, formatNumber, returnTokenFromKey } from 'utils';
+import {
+  getDaysCurrentYear,
+  formatNumber,
+  returnTokenFromKey,
+  getTokenAPRSyrup,
+} from 'utils';
 import useDebouncedChangeHandler from 'utils/useDebouncedChangeHandler';
 import { useInfiniteLoading } from 'utils/useInfiniteLoading';
 import { Skeleton } from '@material-ui/lab';
@@ -235,23 +240,9 @@ const DragonPage: React.FC = () => {
 
   const sortByAPR = useCallback(
     (a: SyrupInfo, b: SyrupInfo) => {
-      const tokenAPRA =
-        a.valueOfTotalStakedAmountInUSDC && a.valueOfTotalStakedAmountInUSDC > 0
-          ? ((a.rewards ?? 0) / a.valueOfTotalStakedAmountInUSDC) *
-            daysCurrentYear *
-            100
-          : 0;
-
-      const tokenAPRB =
-        b.valueOfTotalStakedAmountInUSDC && b.valueOfTotalStakedAmountInUSDC > 0
-          ? ((b.rewards ?? 0) / b.valueOfTotalStakedAmountInUSDC) *
-            daysCurrentYear *
-            100
-          : 0;
-
-      return (tokenAPRA > tokenAPRB ? -1 : 1) * sortIndex;
+      return (getTokenAPRSyrup(a) > getTokenAPRSyrup(b) ? -1 : 1) * sortIndex;
     },
-    [sortIndex, daysCurrentYear],
+    [sortIndex],
   );
   const sortByEarned = useCallback(
     (a: SyrupInfo, b: SyrupInfo) => {

--- a/src/pages/FarmPage/FarmPage.tsx
+++ b/src/pages/FarmPage/FarmPage.tsx
@@ -121,7 +121,9 @@ const FarmPage: React.FC = () => {
   >(undefined);
   const [bulkPairs, setBulkPairs] = useState<any>(null);
   const [pageIndex, setPageIndex] = useState(0);
-  const [farmIndex, setFarmIndex] = useState(GlobalConst.utils.LPFARM_INDEX);
+  const [farmIndex, setFarmIndex] = useState(
+    GlobalConst.farmIndex.LPFARM_INDEX,
+  );
   const [pageloading, setPageLoading] = useState(true); //this is used for not loading farms immediately when user is on farms page
   const [isEndedFarm, setIsEndedFarm] = useState(false);
   const [sortBy, setSortBy] = useState(0);
@@ -135,10 +137,14 @@ const FarmPage: React.FC = () => {
 
   const addedLPStakingInfos = useStakingInfo(
     null,
-    pageloading || farmIndex === GlobalConst.utils.DUALFARM_INDEX || isEndedFarm
+    pageloading ||
+      farmIndex === GlobalConst.farmIndex.DUALFARM_INDEX ||
+      isEndedFarm
       ? 0
       : undefined,
-    pageloading || farmIndex === GlobalConst.utils.DUALFARM_INDEX || isEndedFarm
+    pageloading ||
+      farmIndex === GlobalConst.farmIndex.DUALFARM_INDEX ||
+      isEndedFarm
       ? 0
       : undefined,
     { search: farmSearch, isStaked: stakedOnly },
@@ -146,12 +152,12 @@ const FarmPage: React.FC = () => {
   const addedLPStakingOldInfos = useOldStakingInfo(
     null,
     pageloading ||
-      farmIndex === GlobalConst.utils.DUALFARM_INDEX ||
+      farmIndex === GlobalConst.farmIndex.DUALFARM_INDEX ||
       !isEndedFarm
       ? 0
       : undefined,
     pageloading ||
-      farmIndex === GlobalConst.utils.DUALFARM_INDEX ||
+      farmIndex === GlobalConst.farmIndex.DUALFARM_INDEX ||
       !isEndedFarm
       ? 0
       : undefined,
@@ -159,8 +165,12 @@ const FarmPage: React.FC = () => {
   );
   const addedDualStakingInfos = useDualStakingInfo(
     null,
-    pageloading || farmIndex === GlobalConst.utils.LPFARM_INDEX ? 0 : undefined,
-    pageloading || farmIndex === GlobalConst.utils.LPFARM_INDEX ? 0 : undefined,
+    pageloading || farmIndex === GlobalConst.farmIndex.LPFARM_INDEX
+      ? 0
+      : undefined,
+    pageloading || farmIndex === GlobalConst.farmIndex.LPFARM_INDEX
+      ? 0
+      : undefined,
     { search: farmSearch, isStaked: stakedOnly },
   );
 
@@ -318,7 +328,7 @@ const FarmPage: React.FC = () => {
 
   const addedStakingInfos = useMemo(
     () =>
-      farmIndex === GlobalConst.utils.DUALFARM_INDEX
+      farmIndex === GlobalConst.farmIndex.DUALFARM_INDEX
         ? sortedStakingDualInfos
         : sortedLPStakingInfos,
     [farmIndex, sortedStakingDualInfos, sortedLPStakingInfos],
@@ -354,7 +364,7 @@ const FarmPage: React.FC = () => {
 
   useEffect(() => {
     setPageIndex(0);
-    if (farmIndex === GlobalConst.utils.LPFARM_INDEX) {
+    if (farmIndex === GlobalConst.farmIndex.LPFARM_INDEX) {
       setStakingInfos(sortedLPStakingInfos.slice(0, LOADFARM_COUNT));
     } else {
       setStakingDualInfos(sortedStakingDualInfos.slice(0, LOADFARM_COUNT));
@@ -367,14 +377,14 @@ const FarmPage: React.FC = () => {
   }, [stakingRewardAddress]);
 
   useEffect(() => {
-    if (farmIndex === GlobalConst.utils.LPFARM_INDEX) {
+    if (farmIndex === GlobalConst.farmIndex.LPFARM_INDEX) {
       const currentStakingInfos = stakingInfos || [];
       const stakingInfosToAdd = sortedLPStakingInfos.slice(
         currentStakingInfos.length,
         currentStakingInfos.length + LOADFARM_COUNT,
       );
       setStakingInfos(currentStakingInfos.concat(stakingInfosToAdd));
-    } else if (farmIndex === GlobalConst.utils.DUALFARM_INDEX) {
+    } else if (farmIndex === GlobalConst.farmIndex.DUALFARM_INDEX) {
       const currentDualStakingInfos = stakingDualInfos || [];
       const stakingDualInfosToAdd = sortedStakingDualInfos.slice(
         currentDualStakingInfos.length,
@@ -389,7 +399,7 @@ const FarmPage: React.FC = () => {
 
   const stakingAPYs = useMemo(() => {
     const sortedStakingInfos =
-      farmIndex === GlobalConst.utils.LPFARM_INDEX
+      farmIndex === GlobalConst.farmIndex.LPFARM_INDEX
         ? stakingInfos
         : stakingDualInfos;
     if (bulkPairs && sortedStakingInfos && sortedStakingInfos.length > 0) {
@@ -434,12 +444,12 @@ const FarmPage: React.FC = () => {
         <Box
           className={cx(
             classes.farmSwitch,
-            farmIndex === GlobalConst.utils.LPFARM_INDEX &&
+            farmIndex === GlobalConst.farmIndex.LPFARM_INDEX &&
               classes.activeFarmSwitch,
           )}
           style={{ borderTopLeftRadius: 8, borderBottomLeftRadius: 8 }}
           onClick={() => {
-            setFarmIndex(GlobalConst.utils.LPFARM_INDEX);
+            setFarmIndex(GlobalConst.farmIndex.LPFARM_INDEX);
           }}
         >
           <Typography variant='body1'>LP Mining</Typography>
@@ -447,12 +457,12 @@ const FarmPage: React.FC = () => {
         <Box
           className={cx(
             classes.farmSwitch,
-            farmIndex === GlobalConst.utils.DUALFARM_INDEX &&
+            farmIndex === GlobalConst.farmIndex.DUALFARM_INDEX &&
               classes.activeFarmSwitch,
           )}
           style={{ borderTopRightRadius: 8, borderBottomRightRadius: 8 }}
           onClick={() => {
-            setFarmIndex(GlobalConst.utils.DUALFARM_INDEX);
+            setFarmIndex(GlobalConst.farmIndex.DUALFARM_INDEX);
           }}
         >
           <Typography variant='body1'>Dual Mining</Typography>
@@ -473,7 +483,7 @@ const FarmPage: React.FC = () => {
             <Typography variant='h5'>Earn dQuick</Typography>
             <Typography variant='body2'>
               Stake LP Tokens to earn{' '}
-              {farmIndex === GlobalConst.utils.LPFARM_INDEX
+              {farmIndex === GlobalConst.farmIndex.LPFARM_INDEX
                 ? 'dQUICK + Pool Fees'
                 : 'dQUICK + WMATIC rewards'}
             </Typography>
@@ -686,7 +696,7 @@ const FarmPage: React.FC = () => {
             </Box>
           </Box>
         )}
-        {farmIndex === GlobalConst.utils.LPFARM_INDEX && stakingInfos ? (
+        {farmIndex === GlobalConst.farmIndex.LPFARM_INDEX && stakingInfos ? (
           stakingInfos.map((info: StakingInfo, index) => (
             <FarmLPCard
               key={index}
@@ -695,7 +705,7 @@ const FarmPage: React.FC = () => {
               stakingAPY={stakingAPYs[index]}
             />
           ))
-        ) : farmIndex === GlobalConst.utils.DUALFARM_INDEX &&
+        ) : farmIndex === GlobalConst.farmIndex.DUALFARM_INDEX &&
           stakingDualInfos ? (
           stakingDualInfos.map((info: DualStakingInfo, index) => (
             <FarmDualCard

--- a/src/pages/FarmPage/FarmRewards.tsx
+++ b/src/pages/FarmPage/FarmRewards.tsx
@@ -16,20 +16,14 @@ const FarmRewards: React.FC<{ farmIndex: number; bulkPairs: any }> = ({
   const isMobile = useMediaQuery(breakpoints.down('xs'));
 
   const farmData = useUSDRewardsandFees(
-    farmIndex === GlobalConst.utils.LPFARM_INDEX,
+    farmIndex === GlobalConst.farmIndex.LPFARM_INDEX,
     bulkPairs,
   );
   const dQuickRewardSum = useMemo(() => {
-    if (chainId) {
-      const stakingData = returnStakingInfo()[chainId] ?? [];
-      const rewardSum = stakingData.reduce(
-        (total, item) => total + item.rate,
-        0,
-      );
-      return rewardSum;
-    } else {
-      return 0;
-    }
+    if (!chainId) return 0;
+    const stakingData = returnStakingInfo()[chainId] ?? [];
+    const rewardSum = stakingData.reduce((total, item) => total + item.rate, 0);
+    return rewardSum;
   }, [chainId]);
 
   const getRewardsSection = (isLPFarm: boolean) => (
@@ -83,7 +77,7 @@ const FarmRewards: React.FC<{ farmIndex: number; bulkPairs: any }> = ({
       py={1.5}
       bgcolor={palette.secondary.dark}
     >
-      {farmIndex === GlobalConst.utils.LPFARM_INDEX && (
+      {farmIndex === GlobalConst.farmIndex.LPFARM_INDEX && (
         <>
           <Box
             width={isMobile ? 1 : 1 / 3}
@@ -103,7 +97,7 @@ const FarmRewards: React.FC<{ farmIndex: number; bulkPairs: any }> = ({
           {getRewardsSection(true)}
         </>
       )}
-      {farmIndex === GlobalConst.utils.DUALFARM_INDEX &&
+      {farmIndex === GlobalConst.farmIndex.DUALFARM_INDEX &&
         getRewardsSection(false)}
     </Box>
   );

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1757,3 +1757,12 @@ export function getPriceToQUICKSyrup(syrup: SyrupInfo) {
   );
   return isQUICKStakingToken ? 1 : Number(syrup.dQUICKtoQUICK.toSignificant());
 }
+
+export function getTokenAPRSyrup(syrup: SyrupInfo) {
+  return syrup.valueOfTotalStakedAmountInUSDC &&
+    syrup.valueOfTotalStakedAmountInUSDC > 0
+    ? ((syrup.rewards ?? 0) / syrup.valueOfTotalStakedAmountInUSDC) *
+        getDaysCurrentYear() *
+        100
+    : 0;
+}


### PR DESCRIPTION
- Create separate component for rewards section on farm page
- Add sort functions for dragon syrups
- Move constants for LP or Dual farm to `GlobalConst`
- Fix rewards section breaks for a second when switching lp or dual farms on farm page
- Add loading state on farms/dragons page to fix the app is stuck for some seconds when clicking farm or dragon menu item.
- Add reusable function to get tokenAPR for syrup