### PR TITLE
refactor: Improve scroll event lag

### DIFF
--- a/src/components/CurrencySearchModal/CurrencyRow.tsx
+++ b/src/components/CurrencySearchModal/CurrencyRow.tsx
@@ -190,7 +190,6 @@ const CurrencyRow: React.FC<CurrenyRowProps> = ({
       }}
     >
       <Box className={classes.currencyRow}>
-        {console.log('perfTest: row rendered ')}
         {(otherSelected || isSelected) && <TokenSelectedIcon />}
         <CurrencyLogo currency={currency} size={'32px'} />
         <Box ml={1} height={32}>

--- a/src/pages/DragonPage/DragonsSyrup.tsx
+++ b/src/pages/DragonPage/DragonsSyrup.tsx
@@ -32,7 +32,7 @@ const useStyles = makeStyles(({ palette, breakpoints }) => ({
   },
 }));
 
-const LOADSYRUP_COUNT = 5;
+const LOADSYRUP_COUNT = 10;
 const TOKEN_COLUMN = 1;
 const DEPOSIT_COLUMN = 2;
 const APR_COLUMN = 3;

--- a/src/pages/FarmPage/FarmPage.tsx
+++ b/src/pages/FarmPage/FarmPage.tsx
@@ -80,7 +80,7 @@ const useStyles = makeStyles(({ palette, breakpoints }) => ({
   },
 }));
 
-const LOADFARM_COUNT = 6;
+const LOADFARM_COUNT = 10;
 const POOL_COLUMN = 1;
 const TVL_COLUMN = 2;
 const REWARDS_COLUMN = 3;

--- a/src/utils/useInfiniteLoading.ts
+++ b/src/utils/useInfiniteLoading.ts
@@ -5,6 +5,7 @@ export const useInfiniteLoading = (loadNext: () => void) => {
     onChange: () => {
       loadNext();
     },
+    rootMargin: '100px 0px 600px 0px',
   });
 
   return {


### PR DESCRIPTION
## Changes
- Increase scrollable items count from 5 to 10 on `farm` and `dragon liar` page
- Increase load more item trigger buffer by increasing root margin inside `useInView` hook