### PR TITLE
fix: add background as fallback when switch tabs to avoid blank screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ import 'slick-carousel/slick/slick-theme.css';
 import './i18n';
 import './App.css';
 import { mainTheme } from './theme';
+import Background from 'layouts/Background';
 
 const Web3ProviderNetwork = createWeb3ReactRoot(
   GlobalConst.utils.NetworkContextName,
@@ -59,7 +60,7 @@ const ThemeProvider: React.FC = ({ children }) => {
 const Providers: React.FC = ({ children }) => {
   return (
     <div>
-      <Suspense fallback={null}>
+      <Suspense fallback={<Background fallback={true} />}>
         <ThemeProvider>
           <CssBaseline />
           {children}

--- a/src/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/components/ToggleSwitch/ToggleSwitch.tsx
@@ -7,6 +7,7 @@ const useStyles = makeStyles(({ palette }) => ({
     width: 40,
     height: 20,
     position: 'relative',
+    cursor: 'pointer',
     borderRadius: 10,
     border: (props: any) =>
       props.toggled

--- a/src/layouts/Background.tsx
+++ b/src/layouts/Background.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Box } from '@material-ui/core';
+import { useLocation } from 'react-router-dom';
+import { makeStyles } from '@material-ui/core/styles';
+import HeroBkg from 'assets/images/heroBkg.png';
+import HeroBkg1 from 'assets/images/heroBkg.svg';
+
+const useStyles = makeStyles(({ palette, breakpoints }) => ({
+  heroBkg: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    zIndex: 1,
+    width: '100%',
+    overflow: 'hidden',
+    '& img': {
+      width: '100%',
+      minWidth: 1200,
+    },
+  },
+}));
+
+const Background: React.FC<{ fallback: boolean | undefined }> = ({
+  fallback = false,
+}) => {
+  const classes = useStyles();
+  const { pathname } = useLocation();
+
+  if (fallback) {
+    return <img src={HeroBkg1} alt='Hero Background' />;
+  }
+  return (
+    <>
+      <Box className={classes.heroBkg}>
+        <img
+          src={pathname === '/' ? HeroBkg : HeroBkg1}
+          alt='Hero Background'
+        />
+      </Box>
+    </>
+  );
+};
+
+export default React.memo(Background);

--- a/src/layouts/PageLayout.tsx
+++ b/src/layouts/PageLayout.tsx
@@ -1,28 +1,14 @@
 import React from 'react';
 import { Box } from '@material-ui/core';
-import { useLocation } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
-import HeroBkg from 'assets/images/heroBkg.png';
-import HeroBkg1 from 'assets/images/heroBkg.svg';
 import { Header, Footer, BetaWarningBanner } from 'components';
+import Background from './Background';
 
 const useStyles = makeStyles(({ palette, breakpoints }) => ({
   page: {
     backgroundColor: palette.background.default,
     width: '100%',
     minHeight: '100vh',
-  },
-  heroBkg: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    zIndex: 1,
-    width: '100%',
-    overflow: 'hidden',
-    '& img': {
-      width: '100%',
-      minWidth: 1200,
-    },
   },
   pageWrapper: {
     maxWidth: 1312,
@@ -45,18 +31,12 @@ export interface PageLayoutProps {
 
 const PageLayout: React.FC<PageLayoutProps> = ({ children }) => {
   const classes = useStyles();
-  const { pathname } = useLocation();
 
   return (
     <Box className={classes.page}>
       <BetaWarningBanner />
       <Header />
-      <Box className={classes.heroBkg}>
-        <img
-          src={pathname === '/' ? HeroBkg : HeroBkg1}
-          alt='Hero Background'
-        />
-      </Box>
+      <Background fallback={false} />
       <Box className={classes.pageWrapper}>{children}</Box>
       <Footer />
     </Box>


### PR DESCRIPTION
## Changes
- Fix toggle button hover to pointer instead of text
- Add  background as fallback UI while switching between tabs
- Create reusable background component