### PR TITLE
farm page performance improvements

### DIFF
--- a/src/pages/DragonPage/DragonsSyrup.tsx
+++ b/src/pages/DragonPage/DragonsSyrup.tsx
@@ -10,7 +10,11 @@ import {
   SearchInput,
   CustomSwitch,
 } from 'components';
-import { getTokenAPRSyrup, returnFullWidthMobile } from 'utils';
+import {
+  getPageItemsToLoad,
+  getTokenAPRSyrup,
+  returnFullWidthMobile,
+} from 'utils';
 import useDebouncedChangeHandler from 'utils/useDebouncedChangeHandler';
 import { useInfiniteLoading } from 'utils/useInfiniteLoading';
 import { Skeleton } from '@material-ui/lab';
@@ -24,12 +28,9 @@ const EARNED_COLUMN = 4;
 const DragonsSyrup: React.FC = () => {
   const { palette, breakpoints } = useTheme();
   const isMobile = useMediaQuery(breakpoints.down('xs'));
-  const [pageLoading, setPageLoading] = useState(true); //this is used for not loading syrups immediately when user is on dragons page
+  const [pageLoading, setPageLoading] = useState(false); //this is used for not loading syrups immediately when user is on dragons page
   const [isEndedSyrup, setIsEndedSyrup] = useState(false);
   const [pageIndex, setPageIndex] = useState(0);
-  const [syrupInfos, setSyrupInfos] = useState<SyrupInfo[] | undefined>(
-    undefined,
-  );
   const [sortBy, setSortBy] = useState(0);
   const [sortDesc, setSortDesc] = useState(false);
 
@@ -131,26 +132,17 @@ const DragonsSyrup: React.FC = () => {
   );
 
   useEffect(() => {
-    setSyrupInfos(undefined);
-    setTimeout(() => setPageLoading(false), 500); //load syrups 0.5s after loading page
-  }, []);
-
-  useEffect(() => {
     setPageIndex(0);
-    setSyrupInfos(sortedSyrupInfos.slice(0, LOADSYRUP_COUNT));
-    return () => setSyrupInfos(undefined);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [syrupRewardAddress]);
 
-  useEffect(() => {
-    const currentSyrupInfos = syrupInfos || [];
-    const syrupInfosToAdd = sortedSyrupInfos.slice(
-      currentSyrupInfos.length,
-      currentSyrupInfos.length + LOADSYRUP_COUNT,
-    );
-    setSyrupInfos(currentSyrupInfos.concat(syrupInfosToAdd));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pageIndex]);
+  const syrupInfos = useMemo(() => {
+    return sortedSyrupInfos
+      ? sortedSyrupInfos.slice(
+          0,
+          getPageItemsToLoad(pageIndex, LOADSYRUP_COUNT),
+        )
+      : null;
+  }, [sortedSyrupInfos, pageIndex]);
 
   const loadNext = () => {
     setPageIndex(pageIndex + 1);

--- a/src/pages/FarmPage/FarmsList.tsx
+++ b/src/pages/FarmPage/FarmsList.tsx
@@ -42,12 +42,12 @@ const FarmsList: React.FC<FarmsListProps> = ({ bulkPairs, farmIndex }) => {
   const lairInfo = useLairInfo();
   const isMobile = useMediaQuery(breakpoints.down('xs'));
 
-  const [stakingInfos, setStakingInfos] = useState<StakingInfo[] | undefined>(
-    undefined,
-  );
-  const [stakingDualInfos, setStakingDualInfos] = useState<
-    DualStakingInfo[] | undefined
-  >(undefined);
+  // const [stakingInfos, setStakingInfos] = useState<StakingInfo[] | undefined>(
+  //   undefined,
+  // );
+  // const [stakingDualInfos, setStakingDualInfos] = useState<
+  //   DualStakingInfo[] | undefined
+  // >(undefined);
   const [pageIndex, setPageIndex] = useState(0);
   const [pageloading, setPageLoading] = useState(true); //this is used for not loading farms immediately when user is on farms page
   const [isEndedFarm, setIsEndedFarm] = useState(false);
@@ -268,45 +268,31 @@ const FarmsList: React.FC<FarmsListProps> = ({ bulkPairs, farmIndex }) => {
     : null;
 
   useEffect(() => {
-    setStakingInfos(undefined);
-    setStakingDualInfos(undefined);
+    // setStakingDualInfos(undefined);
     setTimeout(() => setPageLoading(false), 500); //load farms 0.5s after loading page
   }, []);
 
   useEffect(() => {
     setPageIndex(0);
-    if (farmIndex === GlobalConst.farmIndex.LPFARM_INDEX) {
-      setStakingInfos(sortedLPStakingInfos.slice(0, LOADFARM_COUNT));
-    } else {
-      setStakingDualInfos(sortedStakingDualInfos.slice(0, LOADFARM_COUNT));
-    }
-    return () => {
-      setStakingInfos(undefined);
-      setStakingDualInfos(undefined);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [stakingRewardAddress]);
 
-  useEffect(() => {
-    if (farmIndex === GlobalConst.farmIndex.LPFARM_INDEX) {
-      const currentStakingInfos = stakingInfos || [];
-      const stakingInfosToAdd = sortedLPStakingInfos.slice(
-        currentStakingInfos.length,
-        currentStakingInfos.length + LOADFARM_COUNT,
-      );
-      setStakingInfos(currentStakingInfos.concat(stakingInfosToAdd));
-    } else if (farmIndex === GlobalConst.farmIndex.DUALFARM_INDEX) {
-      const currentDualStakingInfos = stakingDualInfos || [];
-      const stakingDualInfosToAdd = sortedStakingDualInfos.slice(
-        currentDualStakingInfos.length,
-        currentDualStakingInfos.length + LOADFARM_COUNT,
-      );
-      setStakingDualInfos(
-        currentDualStakingInfos.concat(stakingDualInfosToAdd),
-      );
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pageIndex]);
+  const stakingInfos = useMemo(() => {
+    return sortedLPStakingInfos
+      ? sortedLPStakingInfos.slice(
+          0,
+          pageIndex === 0 ? LOADFARM_COUNT : LOADFARM_COUNT * pageIndex,
+        )
+      : [];
+  }, [sortedLPStakingInfos, pageIndex]);
+
+  const stakingDualInfos = useMemo(() => {
+    return sortedStakingDualInfos
+      ? sortedStakingDualInfos.slice(
+          0,
+          pageIndex === 0 ? LOADFARM_COUNT : LOADFARM_COUNT * pageIndex,
+        )
+      : [];
+  }, [sortedStakingDualInfos, pageIndex]);
 
   const stakingAPYs = useMemo(() => {
     const sortedStakingInfos =

--- a/src/pages/FarmPage/FarmsList.tsx
+++ b/src/pages/FarmPage/FarmsList.tsx
@@ -47,6 +47,12 @@ const FarmsList: React.FC<FarmsListProps> = ({ bulkPairs, farmIndex }) => {
   const lairInfo = useLairInfo();
   const isMobile = useMediaQuery(breakpoints.down('xs'));
 
+  // const [stakingInfos, setStakingInfos] = useState<StakingInfo[] | undefined>(
+  //   undefined,
+  // );
+  // const [stakingDualInfos, setStakingDualInfos] = useState<
+  //   DualStakingInfo[] | undefined
+  // >(undefined);
   const [pageIndex, setPageIndex] = useState(0);
   const [pageloading, setPageLoading] = useState(false); //this is used for not loading farms immediately when user is on farms page
   const [isEndedFarm, setIsEndedFarm] = useState(false);

--- a/src/pages/FarmPage/FarmsList.tsx
+++ b/src/pages/FarmPage/FarmsList.tsx
@@ -47,12 +47,6 @@ const FarmsList: React.FC<FarmsListProps> = ({ bulkPairs, farmIndex }) => {
   const lairInfo = useLairInfo();
   const isMobile = useMediaQuery(breakpoints.down('xs'));
 
-  // const [stakingInfos, setStakingInfos] = useState<StakingInfo[] | undefined>(
-  //   undefined,
-  // );
-  // const [stakingDualInfos, setStakingDualInfos] = useState<
-  //   DualStakingInfo[] | undefined
-  // >(undefined);
   const [pageIndex, setPageIndex] = useState(0);
   const [pageloading, setPageLoading] = useState(false); //this is used for not loading farms immediately when user is on farms page
   const [isEndedFarm, setIsEndedFarm] = useState(false);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1620,6 +1620,10 @@ export function getDaysCurrentYear() {
 }
 
 export function getOneYearFee(dayVolume: number, reserveUSD: number) {
+  if (!dayVolume || !reserveUSD) {
+    return 0;
+  }
+
   return (
     (dayVolume * GlobalConst.utils.FEEPERCENT * getDaysCurrentYear()) /
     reserveUSD
@@ -2002,4 +2006,8 @@ export function getUSDString(usdValue?: CurrencyAmount) {
 
 export function isSupportedNetwork(ethereum: any) {
   return ethereum && Number(ethereum.chainId) === 137;
+}
+
+export function getPageItemsToLoad(index: number, countsPerPage: number) {
+  return index === 0 ? countsPerPage : countsPerPage * index;
 }


### PR DESCRIPTION
## Changes
- Add loading pools using`useMemo` hook instead of `setState` which causes the whole page to re-render every time list updates
- Add Apy calculations for only loaded pools instead of calculating all at once causing load on the main thread.
- Add Syrup page performance fix