### PR TITLE
add BlockWallet as wallet, fix PendingView bug

### DIFF
--- a/src/assets/images/blockwalletIcon.svg
+++ b/src/assets/images/blockwalletIcon.svg
@@ -1,0 +1,3 @@
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M15 30C23.2843 30 30 23.2843 30 15C30 6.71573 23.2843 0 15 0C6.71573 0 0 6.71573 0 15C0 23.2843 6.71573 30 15 30ZM23.125 6.875H6.875V23.125H23.125V6.875Z" fill="currentColor"/>
+</svg>

--- a/src/components/WalletModal/PendingView.tsx
+++ b/src/components/WalletModal/PendingView.tsx
@@ -50,6 +50,8 @@ const PendingView: React.FC<PendingViewProps> = ({
   tryActivation,
 }) => {
   const isMetamask = (window as any).ethereum?.isMetaMask;
+  const isBlockWallet = (window as any).ethereum?.isBlockWallet;
+  const isBitKeep = (window as any).ethereum?.isBitKeep;
   const classes = useStyles();
 
   return (
@@ -85,6 +87,18 @@ const PendingView: React.FC<PendingViewProps> = ({
               return null;
             }
             if (!isMetamask && option.name === 'MetaMask') {
+              return null;
+            }
+            if (isBitKeep && option.name !== 'BitKeep') {
+              return null;
+            }
+            if (!isBitKeep && option.name === 'BitKeep') {
+              return null;
+            }
+            if (isBlockWallet && option.name !== 'BlockWallet') {
+              return null;
+            }
+            if (!isBlockWallet && option.name === 'BlockWallet') {
               return null;
             }
           }

--- a/src/components/WalletModal/WalletModal.tsx
+++ b/src/components/WalletModal/WalletModal.tsx
@@ -229,12 +229,8 @@ const WalletModal: React.FC<WalletModalProps> = ({
         else if (option.name === 'MetaMask' && !isMetamask) {
           return null;
         }
-        // likewise for Blockwallet
-        else if (option.name === 'Injected' && isBlockWallet) {
-          return null;
-        }
         // likewise for generic
-        else if (option.name === 'Injected' && isMetamask) {
+        else if (option.name === 'Injected' && (isMetamask || isBlockWallet)) {
           return null;
         }
       }

--- a/src/components/WalletModal/WalletModal.tsx
+++ b/src/components/WalletModal/WalletModal.tsx
@@ -162,6 +162,7 @@ const WalletModal: React.FC<WalletModalProps> = ({
   function getOptions() {
     const { ethereum, web3 } = window as any;
     const isMetamask = ethereum && ethereum.isMetaMask;
+    const isBlockWallet = ethereum && ethereum.isBlockWallet;
     const isBitKeep = window.ethereum && (window.ethereum as any).isBitKeep;
     return Object.keys(SUPPORTED_WALLETS).map((key) => {
       const option = SUPPORTED_WALLETS[key];
@@ -189,6 +190,7 @@ const WalletModal: React.FC<WalletModalProps> = ({
               active={
                 option.connector === connector &&
                 (connector !== injected ||
+                  isBlockWallet === (option.name === 'BlockWallet') ||
                   isBitKeep === (option.name === 'BitKeep') ||
                   (!isBitKeep && isMetamask) === (option.name === 'MetaMask'))
               }
@@ -225,6 +227,10 @@ const WalletModal: React.FC<WalletModalProps> = ({
         }
         // don't return metamask if injected provider isn't metamask
         else if (option.name === 'MetaMask' && !isMetamask) {
+          return null;
+        }
+        // likewise for Blockwallet
+        else if (option.name === 'Injected' && isBlockWallet) {
           return null;
         }
         // likewise for generic

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -10,6 +10,7 @@ import {
 } from '../connectors';
 import MetamaskIcon from 'assets/images/metamask.png';
 import BitKeepIcon from 'assets/images/bitkeep.png';
+import BlockWalletIcon from 'assets/images/blockwalletIcon.svg';
 import CoinbaseWalletIcon from 'assets/images/coinbaseWalletIcon.svg';
 import WalletConnectIcon from 'assets/images/walletConnectIcon.svg';
 import PortisIcon from 'assets/images/portisIcon.png';
@@ -95,6 +96,14 @@ export const SUPPORTED_WALLETS: { [key: string]: WalletInfo } = {
     description: 'Easy-to-use browser extension.',
     href: null,
     color: '#E8831D',
+  },
+  BLOCKWALLET: {
+    connector: injected,
+    name: 'BlockWallet',
+    iconName: BlockWalletIcon,
+    description: 'BlockWallet browser extension.',
+    href: null,
+    color: '#1673ff',
   },
   BITKEEP: {
     connector: injected,


### PR DESCRIPTION
This PR adds BlockWallet as a wallet option, using the existing `injected` connector.

![image](https://user-images.githubusercontent.com/63911931/158426346-3795543b-e9eb-4f61-a882-e3a34d74d84f.png)

This PR also fixes an issue with the `PendingView`, where injected wallets other than the selected one, among the generic injected option was shown in the pending view. Now, only the selected option will be shown in the pending modal.

![image](https://user-images.githubusercontent.com/63911931/158426607-8129bcb6-8622-46d5-926c-8cbd78d34d8a.png)
