### PR TITLE
fix: fromNow is not a function.

### DIFF
--- a/src/components/TransactionsTable/TransactionsTable.tsx
+++ b/src/components/TransactionsTable/TransactionsTable.tsx
@@ -10,6 +10,8 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import { TxnType } from 'constants/index';
 import 'components/styles/TransactionsTable.scss';
 
+dayjs.extend(relativeTime);
+
 interface TransactionsTableProps {
   data: any[];
 }


### PR DESCRIPTION
https://beta.quickswap.exchange/#/analytics/pair/0x6e7a5fafcec6bb1e78bae2a1f0b612012bf1482

<img width="973" alt="Screen Shot 2022-06-10 at 00 35 20" src="https://user-images.githubusercontent.com/31362988/172898799-4194716f-f52a-42f3-82c1-077acd6e5849.png">
