### PR TITLE
Fixing halving issue

### DIFF
--- a/src/components/Swap/Swap.tsx
+++ b/src/components/Swap/Swap.tsx
@@ -298,11 +298,16 @@ const Swap: React.FC<{
   }, [maxAmountInput, onUserInput]);
 
   const handleHalfInput = useCallback(() => {
-    maxAmountInput &&
-      onUserInput(
-        Field.INPUT,
-        (Number(maxAmountInput.toExact()) / 2).toString(),
-      );
+    if (!maxAmountInput) {
+      return;
+    }
+
+    const halvedAmount = maxAmountInput.divide('2');
+
+    onUserInput(
+      Field.INPUT,
+      halvedAmount.toFixed(maxAmountInput.currency.decimals),
+    );
   }, [maxAmountInput, onUserInput]);
 
   const atMaxAmountInput = Boolean(


### PR DESCRIPTION
halved amount was unparsable, because their decimals exceed the max decimal input of the token