### PR TITLE
Fix TW connector when multiple injected providers exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "react-virtuoso": "^2.8.4",
     "sass": "^1.51.0",
     "slick-carousel": "^1.8.1",
-    "styled-components": "^5.3.3"
+    "styled-components": "^5.3.3",
+    "tiny-warning": "^1.0.3"
   }
 }

--- a/src/components/AccountDetails/AccountDetails.tsx
+++ b/src/components/AccountDetails/AccountDetails.tsx
@@ -13,6 +13,7 @@ import {
   safeApp,
   trustconnect,
   unstopabbledomains,
+  metamask,
 } from 'connectors';
 import { ExternalLink as LinkIcon } from 'react-feather';
 import 'components/styles/AccountDetails.scss';
@@ -78,6 +79,7 @@ const AccountDetails: React.FC<AccountDetailsProps> = ({
           {formatConnectorName()}
           <Box className='flex items-center'>
             {connector !== injected &&
+              connector !== metamask &&
               connector !== walletlink &&
               connector !== trustconnect &&
               connector !== safeApp && (

--- a/src/components/WalletModal/WalletModal.tsx
+++ b/src/components/WalletModal/WalletModal.tsx
@@ -7,7 +7,7 @@ import ReactGA from 'react-ga';
 import { Box } from '@material-ui/core';
 import MetamaskIcon from 'assets/images/metamask.png';
 import { ReactComponent as Close } from 'assets/images/CloseIcon.svg';
-import { fortmatic, injected, portis, safeApp, trustconnect } from 'connectors';
+import { fortmatic, injected, metamask, portis, safeApp } from 'connectors';
 import { OVERLAY_READY } from 'connectors/Fortmatic';
 import { GlobalConst, SUPPORTED_WALLETS } from 'constants/index';
 import usePrevious from 'hooks/usePrevious';
@@ -23,11 +23,15 @@ import { UAuthConnector } from '@uauth/web3-react';
 import UAuth from '@uauth/js';
 
 import { InjectedConnector } from '@web3-react/injected-connector';
-import { TrustWalletConnector } from 'connectors/TrustWalletConnector';
+import {
+  getTrustWalletInjectedProvider,
+  TrustWalletConnector,
+} from 'connectors/TrustWalletConnector';
 
 import Option from './Option';
 import PendingView from './PendingView';
 import 'components/styles/WalletModal.scss';
+import { getMetaMaskInjectedProvider } from 'connectors/MetaMaskConnector';
 
 const WALLET_VIEWS = {
   OPTIONS: 'options',
@@ -208,25 +212,18 @@ const WalletModal: React.FC<WalletModalProps> = ({
 
   // get wallets user can switch too, depending on device/browser
   function getOptions() {
-    const { ethereum, web3, trustwallet, _oldMetaMask } = window as any;
-    const isMetamask =
-      ethereum && !ethereum.isBitKeep && (ethereum.isMetaMask || _oldMetaMask);
+    const { ethereum, web3, _oldMetaMask } = window as any;
+    const isMetamask = !!getMetaMaskInjectedProvider() || _oldMetaMask;
     const isBlockWallet = ethereum && ethereum.isBlockWallet;
     const isCypherD = ethereum && ethereum.isCypherD;
     const isBitKeep = ethereum && ethereum.isBitKeep;
-    const isTrustWallet = ethereum && ethereum.isTrustWallet;
+    const trustWallet = getTrustWalletInjectedProvider();
 
     // is trust wallet installed?
-    const isTrustWalledInstalled = trustwallet !== undefined;
+    const isTrustWalledInstalled = !!trustWallet;
 
     return Object.keys(SUPPORTED_WALLETS).map((key) => {
       const option = SUPPORTED_WALLETS[key];
-
-      if (option.connector === trustconnect) {
-        if (!isTrustWalledInstalled) {
-          option.installLink = process.env.REACT_APP_TRUST_WALLET_INSTALL_LINK;
-        }
-      }
 
       //disable safe app by in the list
       if (option.connector === safeApp) {
@@ -274,7 +271,7 @@ const WalletModal: React.FC<WalletModalProps> = ({
       }
 
       // overwrite injected when needed
-      if (option.connector === injected) {
+      if (option.connector === injected || option.connector === metamask) {
         // don't show injected if there's no injected provider
         if (!(web3 || ethereum)) {
           if (option.name === GlobalConst.walletName.METAMASK) {

--- a/src/connectors/MetaMaskConnector.ts
+++ b/src/connectors/MetaMaskConnector.ts
@@ -1,0 +1,313 @@
+import { AbstractConnectorArguments, ConnectorUpdate } from '@web3-react/types';
+import { AbstractConnector } from '@web3-react/abstract-connector';
+import warning from 'tiny-warning';
+
+type SendReturnResult = { result: any };
+type SendReturn = any;
+
+type Send = (
+  method: string,
+  params?: any[],
+) => Promise<SendReturnResult | SendReturn>;
+type SendOld = ({
+  method,
+}: {
+  method: string;
+}) => Promise<SendReturnResult | SendReturn>;
+
+declare const __DEV__: boolean;
+
+type WindowEthereumMetamask = Window['ethereum'] & {
+  isMetaMask?: boolean;
+  isBraveWallet?: boolean;
+  isAvalanche?: boolean;
+  isKuCoinWallet?: boolean;
+  isPortal?: boolean;
+  isTokenPocket?: boolean;
+  isTokenary?: boolean;
+  isBitKeep?: boolean;
+  providers?: Array<WindowEthereumMetamask>;
+  _events?: any;
+  _state?: any;
+};
+
+function parseSendReturn(sendReturn: SendReturnResult | SendReturn): any {
+  return sendReturn.hasOwnProperty('result') ? sendReturn.result : sendReturn;
+}
+
+export function getMetaMaskInjectedProvider(): Window['ethereum'] {
+  const getMetaMask = (ethereum: WindowEthereumMetamask) => {
+    const isMetaMask = !!ethereum?.isMetaMask;
+    if (!isMetaMask) return;
+    // Brave tries to make itself look like MetaMask
+    // Could also try RPC `web3_clientVersion` if following is unreliable
+    if (ethereum.isBraveWallet && !ethereum._events && !ethereum._state) return;
+    if (ethereum.isAvalanche) return;
+    if (ethereum.isKuCoinWallet) return;
+    if (ethereum.isPortal) return;
+    if (ethereum.isTokenPocket) return;
+    if (ethereum.isTokenary) return;
+    if (ethereum.isBitKeep) return;
+    return window.ethereum;
+  };
+
+  const injectedProviderExist =
+    typeof window !== 'undefined' && typeof window.ethereum !== 'undefined';
+
+  // No injected providers exist.
+  if (!injectedProviderExist) {
+    return;
+  }
+
+  const ethereum = window.ethereum as WindowEthereumMetamask;
+
+  const ethereumMetamask = getMetaMask(ethereum);
+
+  if (ethereumMetamask) {
+    return ethereumMetamask;
+  }
+
+  return ethereum.providers?.find(getMetaMask);
+}
+
+export class NoEthereumProviderError extends Error {
+  public constructor() {
+    super();
+    this.name = this.constructor.name;
+    this.message = 'No Ethereum provider was found on this.provider.';
+  }
+}
+
+export class UserRejectedRequestError extends Error {
+  public constructor() {
+    super();
+    this.name = this.constructor.name;
+    this.message = 'The user rejected the request.';
+  }
+}
+
+export class MetaMaskConnector extends AbstractConnector {
+  provider: Window['ethereum'];
+
+  constructor(kwargs: AbstractConnectorArguments) {
+    super(kwargs);
+
+    this.handleNetworkChanged = this.handleNetworkChanged.bind(this);
+    this.handleChainChanged = this.handleChainChanged.bind(this);
+    this.handleAccountsChanged = this.handleAccountsChanged.bind(this);
+    this.handleClose = this.handleClose.bind(this);
+  }
+
+  private handleChainChanged(chainId: string | number): void {
+    if (__DEV__) {
+      console.log("Handling 'chainChanged' event with payload", chainId);
+    }
+    this.emitUpdate({ chainId, provider: this.provider });
+  }
+
+  private handleAccountsChanged(accounts: string[]): void {
+    if (__DEV__) {
+      console.log("Handling 'accountsChanged' event with payload", accounts);
+    }
+    if (accounts.length === 0) {
+      this.emitDeactivate();
+    } else {
+      this.emitUpdate({ account: accounts[0] });
+    }
+  }
+
+  private handleClose(code: number, reason: string): void {
+    if (__DEV__) {
+      console.log("Handling 'close' event with payload", code, reason);
+    }
+    this.emitDeactivate();
+  }
+
+  private handleNetworkChanged(networkId: string | number): void {
+    if (__DEV__) {
+      console.log("Handling 'networkChanged' event with payload", networkId);
+    }
+    this.emitUpdate({ chainId: networkId, provider: this.provider });
+  }
+
+  public async activate(): Promise<ConnectorUpdate> {
+    this.provider = getMetaMaskInjectedProvider();
+
+    if (!this.provider) {
+      throw new NoEthereumProviderError();
+    }
+
+    if (this.provider.on) {
+      this.provider.on('chainChanged', this.handleChainChanged);
+      this.provider.on('accountsChanged', this.handleAccountsChanged);
+      this.provider.on('close', this.handleClose);
+      this.provider.on('networkChanged', this.handleNetworkChanged);
+    }
+
+    if ((this.provider as any).isMetaMask) {
+      (this.provider as any).autoRefreshOnNetworkChange = false;
+    }
+
+    // try to activate + get account via eth_requestAccounts
+    let account;
+    try {
+      account = await (this.provider.send as Send)('eth_requestAccounts').then(
+        (sendReturn) => parseSendReturn(sendReturn)[0],
+      );
+    } catch (error) {
+      if ((error as any).code === 4001) {
+        throw new UserRejectedRequestError();
+      }
+      warning(
+        false,
+        'eth_requestAccounts was unsuccessful, falling back to enable',
+      );
+    }
+
+    // if unsuccessful, try enable
+    if (!account) {
+      // if enable is successful but doesn't return accounts, fall back to getAccount (not happy i have to do this...)
+      account = await this.provider
+        .enable()
+        .then((sendReturn) => sendReturn && parseSendReturn(sendReturn)[0]);
+    }
+
+    return { provider: this.provider, ...(account ? { account } : {}) };
+  }
+
+  public async getProvider(): Promise<any> {
+    return this.provider;
+  }
+
+  public async getChainId(): Promise<number | string> {
+    if (!this.provider) {
+      throw new NoEthereumProviderError();
+    }
+
+    let chainId;
+    try {
+      chainId = await (this.provider.send as Send)('eth_chainId').then(
+        parseSendReturn,
+      );
+    } catch {
+      warning(
+        false,
+        'eth_chainId was unsuccessful, falling back to net_version',
+      );
+    }
+
+    if (!chainId) {
+      try {
+        chainId = await (this.provider.send as Send)('net_version').then(
+          parseSendReturn,
+        );
+      } catch {
+        warning(
+          false,
+          'net_version was unsuccessful, falling back to net version v2',
+        );
+      }
+    }
+
+    if (!chainId) {
+      try {
+        chainId = parseSendReturn(
+          ((this.provider.send as unknown) as SendOld)({
+            method: 'net_version',
+          }),
+        );
+      } catch {
+        warning(
+          false,
+          'net_version v2 was unsuccessful, falling back to manual matches and static properties',
+        );
+      }
+    }
+
+    if (!chainId) {
+      if ((this.provider as any).isDapper) {
+        chainId = parseSendReturn(
+          (this.provider as any).cachedResults.net_version,
+        );
+      } else {
+        chainId =
+          (this.provider as any).chainId ||
+          (this.provider as any).netVersion ||
+          (this.provider as any).networkVersion ||
+          (this.provider as any)._chainId;
+      }
+    }
+
+    return chainId;
+  }
+
+  public async getAccount(): Promise<null | string> {
+    if (!this.provider) {
+      throw new NoEthereumProviderError();
+    }
+
+    let account;
+    try {
+      account = await (this.provider.send as Send)('eth_accounts').then(
+        (sendReturn) => parseSendReturn(sendReturn)[0],
+      );
+    } catch {
+      warning(false, 'eth_accounts was unsuccessful, falling back to enable');
+    }
+
+    if (!account) {
+      try {
+        account = await this.provider
+          .enable()
+          .then((sendReturn) => parseSendReturn(sendReturn)[0]);
+      } catch {
+        warning(
+          false,
+          'enable was unsuccessful, falling back to eth_accounts v2',
+        );
+      }
+    }
+
+    if (!account) {
+      account = parseSendReturn(
+        ((this.provider.send as unknown) as SendOld)({
+          method: 'eth_accounts',
+        }),
+      )[0];
+    }
+
+    return account;
+  }
+
+  public deactivate() {
+    if (this.provider && this.provider.removeListener) {
+      this.provider.removeListener('chainChanged', this.handleChainChanged);
+      this.provider.removeListener(
+        'accountsChanged',
+        this.handleAccountsChanged,
+      );
+      this.provider.removeListener('close', this.handleClose);
+      this.provider.removeListener('networkChanged', this.handleNetworkChanged);
+    }
+  }
+
+  public async isAuthorized(): Promise<boolean> {
+    if (!this.provider) {
+      return false;
+    }
+
+    try {
+      return await (this.provider.send as Send)('eth_accounts').then(
+        (sendReturn) => {
+          if (parseSendReturn(sendReturn).length > 0) {
+            return true;
+          } else {
+            return false;
+          }
+        },
+      );
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/connectors/TrustWalletConnector.ts
+++ b/src/connectors/TrustWalletConnector.ts
@@ -7,19 +7,64 @@ interface TrustWalletConnectorArguments {
   supportedChainIds?: number[];
 }
 
+type WindowEthereumTrust = Window['ethereum'] & {
+  isTrust?: boolean;
+  providers?: Array<WindowEthereumTrust>;
+};
+
+type WindowTrust = Window & {
+  trustWallet?: WindowEthereumTrust;
+};
+
+export function getTrustWalletInjectedProvider(): Window['ethereum'] {
+  const isTrustWallet = (ethereum?: WindowEthereumTrust) => {
+    // Identify if Trust Wallet injected provider is present.
+    const trustWallet = !!ethereum?.isTrust;
+
+    return trustWallet;
+  };
+
+  const injectedProviderExist =
+    typeof window !== 'undefined' && typeof window.ethereum !== 'undefined';
+
+  // No injected providers exist.
+  if (!injectedProviderExist) {
+    return;
+  }
+
+  const ethereum = window.ethereum as WindowEthereumTrust;
+
+  // Trust Wallet was injected into window.ethereum.
+  if (isTrustWallet(ethereum)) {
+    return window.ethereum;
+  }
+
+  // Trust Wallet provider might be replaced by another
+  // injected provider, check the providers array.
+  if (ethereum?.providers) {
+    return ethereum.providers.find(isTrustWallet);
+  }
+
+  // In some cases injected providers can replace window.ethereum
+  // without updating the providers array. In those instances the Trust Wallet
+  // can be installed and its provider instance can be retrieved by
+  // looking at the global `trustwallet` object.
+  return (window as WindowTrust).trustWallet;
+}
+
 export class TrustWalletConnector extends AbstractConnector {
   private provider: any;
 
   constructor({ supportedChainIds }: TrustWalletConnectorArguments) {
     super({ supportedChainIds });
+
+    this.handleAccountsChanged = this.handleAccountsChanged.bind(this);
+    this.handleChainChanged = this.handleChainChanged.bind(this);
+    this.handleDisconnect = this.handleDisconnect.bind(this);
   }
 
   public async activate(): Promise<ConnectorUpdate> {
-    const ethereum = window.ethereum as any;
-
-    if (ethereum && ethereum.isTrustWallet === true) {
-      this.provider = (window as any).ethereum;
-    }
+    this.provider = getTrustWalletInjectedProvider();
 
     const accounts = await this.provider.request({
       method: 'eth_requestAccounts',
@@ -27,8 +72,9 @@ export class TrustWalletConnector extends AbstractConnector {
 
     const account = accounts[0];
 
-    this.provider.on('chainChanged', this.handleChainChanged);
-    this.provider.on('accountsChanged', this.handleAccountsChanged);
+    this.provider.addListener('chainChanged', this.handleChainChanged);
+    this.provider.addListener('accountsChanged', this.handleAccountsChanged);
+    this.provider.addListener('disconnect', this.handleDisconnect);
 
     return { provider: this.provider, account: account };
   }
@@ -51,10 +97,10 @@ export class TrustWalletConnector extends AbstractConnector {
   public deactivate(): void {
     this.provider.removeListener('chainChanged', this.handleChainChanged);
     this.provider.removeListener('accountsChanged', this.handleAccountsChanged);
+    this.provider.removeListener('disconnect', this.handleDisconnect);
   }
 
   public async close(): Promise<void> {
-    this.provider.close();
     this.emitDeactivate();
   }
 
@@ -62,7 +108,15 @@ export class TrustWalletConnector extends AbstractConnector {
     this.emitUpdate({ chainId: chainId });
   }
 
+  private handleDisconnect() {
+    this.close();
+  }
+
   private handleAccountsChanged(accounts: string[]): void {
-    this.emitUpdate({ account: accounts[0] });
+    if (accounts.length === 0) {
+      this.close();
+    } else {
+      this.emitUpdate({ account: accounts[0] });
+    }
   }
 }

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -10,7 +10,11 @@ import { FortmaticConnector } from './Fortmatic';
 import { ArkaneConnector } from './Arkane';
 import { NetworkConnector } from './NetworkConnector';
 import { SafeAppConnector } from './SafeApp';
-import { TrustWalletConnector } from './TrustWalletConnector';
+import {
+  getTrustWalletInjectedProvider,
+  TrustWalletConnector,
+} from './TrustWalletConnector';
+import { MetaMaskConnector } from './MetaMaskConnector';
 
 const POLLING_INTERVAL = 12000;
 
@@ -44,6 +48,10 @@ export const injected = new InjectedConnector({
   supportedChainIds: [137, 80001],
 });
 
+export const metamask = new MetaMaskConnector({
+  supportedChainIds: [137, 80001],
+});
+
 export const safeApp = new SafeAppConnector();
 
 // mainnet only
@@ -54,9 +62,15 @@ export const walletconnect = new WalletConnectConnector({
 });
 
 // mainnet only
-export const trustconnect = new TrustWalletConnector({
-  supportedChainIds: [137],
-});
+export const trustconnect = !!getTrustWalletInjectedProvider()
+  ? new TrustWalletConnector({
+      supportedChainIds: [137],
+    })
+  : new WalletConnectConnector({
+      rpc: { 137: NETWORK_URL },
+      bridge: 'https://bridge.walletconnect.org',
+      qrcode: true,
+    });
 
 // mainnet only
 export const arkaneconnect = new ArkaneConnector({

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -9,6 +9,7 @@ import {
   safeApp,
   trustconnect,
   unstopabbledomains,
+  metamask,
 } from '../connectors';
 import MetamaskIcon from 'assets/images/metamask.png';
 import BlockWalletIcon from 'assets/images/blockwalletIcon.svg';
@@ -151,7 +152,7 @@ export const SUPPORTED_WALLETS: { [key: string]: WalletInfo } = {
     color: '#E8831D',
   },
   METAMASK: {
-    connector: injected,
+    connector: metamask,
     name: GlobalConst.walletName.METAMASK,
     iconName: MetamaskIcon,
     description: 'Easy-to-use browser extension.',


### PR DESCRIPTION
## General Changes

- Update `TrustWalletConnector` to handle provider `disconnect` and correct account disconnect events.
- Implement `getTrustWalletInjectedProvider` function to check if the TW web extension is installed.
- Ensure that TW injected provider does not conflict with others.
- Render QR code when users try to connect with TW, but do not have web extension installed.
- Connect TW via deep linking in mobile.
- Fix the issue with the default MetaMask connector, being unable to recognize MM's injected provider when another wallet is installed.

## Developer Notes

Resolves #541

**For internal QA assessment, you will have to use the latest Alpha release of the TW web extension, as it contains significant patches and fixes. However we will have to whitelist your email addresses to access the download page from the Chrome Webstore. Please provide us with this information. Else, you will have to wait for the next public release.** 