### PR TITLE
Fix wallchain

### DIFF
--- a/src/components/Swap/SwapBestTrade.tsx
+++ b/src/components/Swap/SwapBestTrade.tsx
@@ -838,7 +838,8 @@ const SwapBestTrade: React.FC<{
         optimalRate &&
         account &&
         library &&
-        chainId
+        chainId &&
+        approval === ApprovalState.APPROVED
       ) {
         setBonusRouteFound(false);
         setBonusRouteLoading(true);
@@ -892,7 +893,19 @@ const SwapBestTrade: React.FC<{
     outputCurrencySymbol,
     outputCurrencyAddress,
     typedValue,
+    approval, //Added to trigger bonus route search when approval changes
   ]);
+
+  //Reset approvalSubmitted when approval changes, it's needed when user hadn't nor paraswap neither wallchain approvals
+  useEffect(() => {
+    if (
+      bonusRouteFound &&
+      (approval === ApprovalState.NOT_APPROVED ||
+        approval === ApprovalState.UNKNOWN)
+    ) {
+      setApprovalSubmitted(false);
+    }
+  }, [approval, bonusRouteFound]);
 
   useEffect(() => {
     fetchOptimalRate();

--- a/src/hooks/useApproveCallback.ts
+++ b/src/hooks/useApproveCallback.ts
@@ -291,15 +291,19 @@ export function useApproveCallbackFromBestTrade(
   currency?: Currency,
   optimalRate?: OptimalRate,
   bonusRouteFound?: boolean,
+  atMaxAmountInput?: boolean,
 ): [ApprovalState, () => Promise<void>] {
   const { chainId } = useActiveWeb3React();
   const amountToApprove = useMemo(
     () =>
       optimalRate
-        ? new Fraction(ONE).add(allowedSlippage).multiply(optimalRate.srcAmount)
-            .quotient
+        ? atMaxAmountInput
+          ? new Fraction(ONE).multiply(optimalRate.srcAmount).quotient
+          : new Fraction(ONE)
+              .add(allowedSlippage)
+              .multiply(optimalRate.srcAmount).quotient
         : undefined,
-    [optimalRate, allowedSlippage],
+    [optimalRate, allowedSlippage, atMaxAmountInput],
   );
 
   return useApproveCallbackV3(


### PR DESCRIPTION
First problem. When user haven't approved any relevant spender, he is asked to approve Paraswap first. Then, after successful approve Wallchain's api hasn't been called on approval stage but transaction still could be upgraded. It causes transactions without allowance. So `approval` was added to deps of Wallchain's hook.

Second problem. In allowance calculation was used `amount + slippage`. In case of 100% swap it makes no sense. Also approving **only** available amount is the flow that wallets force. The real problem is that when user approves all available balance in the wallet it's still lower then `balance + slippage`, so transaction couldn't be created.