### PR TITLE
Fix select range in v3 pools

### DIFF
--- a/src/pages/PoolsPage/v3/SupplyLiquidityV3/containers/SelectRange/index.tsx
+++ b/src/pages/PoolsPage/v3/SupplyLiquidityV3/containers/SelectRange/index.tsx
@@ -93,7 +93,12 @@ export function SelectRange({
       onChangeLiquidityRangeType(GlobalConst.v3LiquidityRangeType.MANUAL_RANGE);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currencyA, currencyB]);
+  }, [
+    currencyA?.isNative,
+    currencyA?.wrapped.address,
+    currencyB?.isNative,
+    currencyB?.wrapped.address,
+  ]);
 
   const isStablecoinPair = useMemo(() => {
     if (!currencyA || !currencyB) return false;


### PR DESCRIPTION
Fix the issue it is selecting gamma automatically after selecting manual range when adding liquidity in v3