### PR TITLE
Update logic to get token balance

### DIFF
--- a/src/config/polygon.json
+++ b/src/config/polygon.json
@@ -93,5 +93,5 @@
   },
   "maxHops": 3,
   "maxChunks": 400,
-  "blocksPerFetch": 30
+  "blocksPerFetch": 5
 }


### PR DESCRIPTION
As I checked multicall-redux, we don't need to create internal state. If we fix json file, token balance is updated after tx confirmed.