### PR TITLE
[WIP] Changing ad baseUrl to api.quickswap.exchange

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -52,7 +52,7 @@
     <script>
       document.addEventListener('DOMContentLoaded', function() {
         HypeLab.initialize({
-          URL: 'https://api.hypelab.com',
+          baseUrl: 'https://api.quickswap.exchange',
           propertySlug: '81c00452a9',
           environment: 'production',
         });


### PR DESCRIPTION
After several months of impression declines, HypeLab is interested in testing a potential fix. NOTE: DNS records must be updated to route requests through `api.quickswap.exchange` before deploying this change.