### PR TITLE
Fix reward amount

### DIFF
--- a/src/hooks/v3/useV3Farms.ts
+++ b/src/hooks/v3/useV3Farms.ts
@@ -516,7 +516,7 @@ export const useMerklFarms = () => {
                 0,
               ),
             almAPR: farm?.meanAPR ?? 0,
-            label: farm?.ammName,
+            label: 'QuickswapAlgebra',
           },
         ])
         .filter((alm: any) => alm.almTVL > 0)
@@ -650,7 +650,11 @@ export const useGetMerklRewards = (
             reasons = {
               ...reasons,
               [breakdown.reason]: {
-                unclaimed: BigInt(breakdown.amount) - BigInt(breakdown.claimed),
+                unclaimed: ((reasons as any)[breakdown.reason] as any)
+                ? ((reasons as any)[breakdown.reason] as any).unclaimed +
+                  BigInt(breakdown.amount) -
+                  BigInt(breakdown.claimed)
+                : BigInt(breakdown.amount) - BigInt(breakdown.claimed),
               },
             };
           },


### PR DESCRIPTION
Merkle v3 returns the claimed amount for each pool ID.  
However, Merkle v4 returns the claimed amount for each combination of pool ID and campaign ID, where each pool ID can have multiple campaign IDs.  
This PR fix this by aggregating the claimed amount for the same pool ID across multiple campaign IDs.