### PR TITLE
Fix algebra v4 liquidity in farm page

### DIFF
--- a/src/hooks/v3/useV3Farms.ts
+++ b/src/hooks/v3/useV3Farms.ts
@@ -14,6 +14,7 @@ import {
   useMasterChefContract,
   useUNIV3NFTPositionManagerContract,
   useV3NFTPositionManagerContract,
+  useV4NFTPositionManagerContract,
 } from 'hooks/useContract';
 import { useEffect, useMemo } from 'react';
 import { useSelectedTokenList } from 'state/lists/hooks';
@@ -1047,9 +1048,14 @@ export function useV3PositionsFromPool(
 ) {
   const { account } = useActiveWeb3React();
   const algebraPositionManager = useV3NFTPositionManagerContract();
+  const algebraPositionV4Manager = useV4NFTPositionManagerContract();
   const uniPositionManager = useUNIV3NFTPositionManagerContract();
-  const positionManager = fee ? uniPositionManager : algebraPositionManager;
-
+  const isV4 = !algebraPositionManager;
+  const positionManager = fee
+    ? uniPositionManager
+    : isV4
+    ? algebraPositionV4Manager
+    : algebraPositionManager;
   const {
     loading: balanceLoading,
     result: balanceResult,
@@ -1092,6 +1098,7 @@ export function useV3PositionsFromPool(
   const { positions, loading: positionsLoading } = useV3PositionsFromTokenIds(
     tokenIds,
     !!fee,
+    isV4,
   );
 
   const filteredPositions = useMemo(() => {


### PR DESCRIPTION
In the old codebase, the farm detail page used an outdated version of Algebra to retrieve the token balance (not using Algebra 1.2). This PR resolves the issue by falling back to Algebra 1.2 if the original version of Algebra is not found.