### PR TITLE
Remove withdrawOnly flag in USDT-DAI pair

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -964,7 +964,6 @@ export const GammaPairs: {
         token1Address: '0xc2132d05d31c914a87c6611c10748aeb04b58e8f',
         ableToFarm: true,
         pid: 55,
-        withdrawOnly: true,
       },
     ],
     '0x2791bca1f2de4661ed88a30c99a7a9449aa84174-0x385eeac5cb85a38a9a07a70c73e0a3271cfb54a7': [

--- a/src/pages/PerpsPage/FooterOrdersTable.tsx
+++ b/src/pages/PerpsPage/FooterOrdersTable.tsx
@@ -218,9 +218,18 @@ const FooterOrdersTable: React.FC<{
             id: 'action',
             label: '',
             html: (item: Order) =>
-              item.status === OrderStatus.FILLED ||
-              item.status === OrderStatus.REJECTED ||
-              item.status === OrderStatus.CANCELLED ? (
+              (item.status &&
+                [
+                  OrderStatus.FILLED,
+                  OrderStatus.REJECTED,
+                  OrderStatus.CANCELLED,
+                ].includes(item.status)) ||
+              (item.algo_status &&
+                [
+                  OrderStatus.FILLED,
+                  OrderStatus.REJECTED,
+                  OrderStatus.CANCELLED,
+                ].includes(item.algo_status)) ? (
                 <></>
               ) : (
                 <CancelOrderButton


### PR DESCRIPTION
 - Fix the following bug report
"When trying to make a USDT-DAI manual position with “stablecoins” selected on polygon PoS, it shows $DAI as a withdraw only vault"
-  Fix an bug to display cancel button for filled order in perps order tab