### PR TITLE
Fix steer vault in pool page

### DIFF
--- a/src/hooks/v3/useSteerData.ts
+++ b/src/hooks/v3/useSteerData.ts
@@ -192,154 +192,158 @@ export const useSteerVaults = (chainId: ChainId) => {
     vaultAddresses.map((address) => [address]),
   );
 
-  const vaultDetails: SteerVault[] = vaultDetailCalls.map((call, index) => {
-    const vaultAddress = vaultAddresses[index];
-    const vaultRegistryDetailCall = vaultRegistryDetailCalls[index];
-    const vaultRegistryData =
-      !vaultRegistryDetailCall.loading &&
-      vaultRegistryDetailCall.result &&
-      vaultRegistryDetailCall.result.length > 0
-        ? vaultRegistryDetailCall.result[0]
-        : undefined;
-    const vaultData =
-      !call.loading && call.result && call.result.length > 0
-        ? call.result[0]
-        : undefined;
-    const vaultType =
-      vaultData && vaultData.length > 0 ? vaultData[0] : undefined;
-    const token0Address =
-      vaultData && vaultData.length > 1 ? vaultData[1] : undefined;
-    const token1Address =
-      vaultData && vaultData.length > 2 ? vaultData[2] : undefined;
-    const vaultName =
-      vaultData && vaultData.length > 3 ? vaultData[3] : undefined;
-    const vaultSymbol =
-      vaultData && vaultData.length > 4 ? vaultData[4] : undefined;
-    const vaultDecimals =
-      vaultData && vaultData.length > 5 && vaultData[5]
-        ? Number(vaultData[5])
-        : 18;
-    const token0Name =
-      vaultData && vaultData.length > 6 ? vaultData[6] : undefined;
-    const token1Name =
-      vaultData && vaultData.length > 7 ? vaultData[7] : undefined;
-    const token0Symbol =
-      vaultData && vaultData.length > 8 ? vaultData[8] : undefined;
-    const token1Symbol =
-      vaultData && vaultData.length > 9 ? vaultData[9] : undefined;
-    const token0Decimals =
-      vaultData && vaultData.length > 10 && vaultData[10]
-        ? Number(vaultData[10])
-        : undefined;
-    const token1Decimals =
-      vaultData && vaultData.length > 11 && vaultData[11]
-        ? Number(vaultData[11])
-        : undefined;
-    const token0V2 =
-      token0Address && token0Decimals
-        ? getTokenFromAddress(token0Address, chainId, tokenMap, [
-            new TokenV2(
-              chainId,
-              token0Address,
-              token0Decimals,
-              token0Symbol,
-              token0Name,
-            ),
-          ])
-        : undefined;
-    const token1V2 =
-      token1Address && token1Decimals
-        ? getTokenFromAddress(token1Address, chainId, tokenMap, [
-            new TokenV2(
-              chainId,
-              token1Address,
-              token1Decimals,
-              token1Symbol,
-              token1Name,
-            ),
-          ])
-        : undefined;
-    const token0 = token0V2 ? toV3Token(token0V2) : undefined;
-    const token1 = token1V2 ? toV3Token(token1V2) : undefined;
-    const feeTier =
-      chainId === ChainId.MATIC || chainId === ChainId.LAYERX
-        ? undefined
-        : vaultData && vaultData.length > 12
-        ? vaultData[12]
-        : undefined;
-    const totalLPIndex = chainId === ChainId.MANTA ? 13 : 12;
-    const totalLPTokensIssued =
-      vaultData && vaultData.length > totalLPIndex
-        ? vaultData[totalLPIndex]
-        : undefined;
-    const token0BalanceIndex = chainId === ChainId.MANTA ? 14 : 13;
-    const token0Balance =
-      vaultData && vaultData.length > token0BalanceIndex
-        ? vaultData[token0BalanceIndex]
-        : undefined;
-    const token1BalanceIndex = chainId === ChainId.MANTA ? 15 : 14;
-    const token1Balance =
-      vaultData && vaultData.length > token1BalanceIndex
-        ? vaultData[token1BalanceIndex]
-        : undefined;
-    const vaultCreatorIndex = chainId === ChainId.MANTA ? 16 : 15;
-    const vaultCreator =
-      vaultData && vaultData.length > vaultCreatorIndex
-        ? vaultData[vaultCreatorIndex]
-        : undefined;
+  const vaultDetails: SteerVault[] = vaultDetailCalls
+    .map((call, index) => {
+      const vaultAddress = vaultAddresses[index];
+      const vaultRegistryDetailCall = vaultRegistryDetailCalls[index];
+      const vaultRegistryData =
+        !vaultRegistryDetailCall.loading &&
+        vaultRegistryDetailCall.result &&
+        vaultRegistryDetailCall.result.length > 0
+          ? vaultRegistryDetailCall.result[0]
+          : undefined;
+      const vaultData =
+        !call.loading && call.result && call.result.length > 0
+          ? call.result[0]
+          : undefined;
+      const vaultType =
+        vaultData && vaultData.length > 0 ? vaultData[0] : undefined;
+      const token0Address =
+        vaultData && vaultData.length > 1 ? vaultData[1] : undefined;
+      const token1Address =
+        vaultData && vaultData.length > 2 ? vaultData[2] : undefined;
+      const vaultName =
+        vaultData && vaultData.length > 3 ? vaultData[3] : undefined;
+      const vaultSymbol =
+        vaultData && vaultData.length > 4 ? vaultData[4] : undefined;
+      const vaultDecimals =
+        vaultData && vaultData.length > 5 && vaultData[5]
+          ? Number(vaultData[5])
+          : 18;
+      const token0Name =
+        vaultData && vaultData.length > 6 ? vaultData[6] : undefined;
+      const token1Name =
+        vaultData && vaultData.length > 7 ? vaultData[7] : undefined;
+      const token0Symbol =
+        vaultData && vaultData.length > 8 ? vaultData[8] : undefined;
+      const token1Symbol =
+        vaultData && vaultData.length > 9 ? vaultData[9] : undefined;
+      const token0Decimals =
+        vaultData && vaultData.length > 10 && vaultData[10]
+          ? Number(vaultData[10])
+          : undefined;
+      const token1Decimals =
+        vaultData && vaultData.length > 11 && vaultData[11]
+          ? Number(vaultData[11])
+          : undefined;
+      const token0V2 =
+        token0Address && token0Decimals
+          ? getTokenFromAddress(token0Address, chainId, tokenMap, [
+              new TokenV2(
+                chainId,
+                token0Address,
+                token0Decimals,
+                token0Symbol,
+                token0Name,
+              ),
+            ])
+          : undefined;
+      const token1V2 =
+        token1Address && token1Decimals
+          ? getTokenFromAddress(token1Address, chainId, tokenMap, [
+              new TokenV2(
+                chainId,
+                token1Address,
+                token1Decimals,
+                token1Symbol,
+                token1Name,
+              ),
+            ])
+          : undefined;
+      const token0 = token0V2 ? toV3Token(token0V2) : undefined;
+      const token1 = token1V2 ? toV3Token(token1V2) : undefined;
+      const feeTier =
+        chainId === ChainId.MATIC || chainId === ChainId.LAYERX
+          ? undefined
+          : vaultData && vaultData.length > 12
+          ? vaultData[12]
+          : undefined;
+      const totalLPIndex = chainId === ChainId.MANTA ? 13 : 12;
+      const totalLPTokensIssued =
+        vaultData && vaultData.length > totalLPIndex
+          ? vaultData[totalLPIndex]
+          : undefined;
+      const token0BalanceIndex = chainId === ChainId.MANTA ? 14 : 13;
+      const token0Balance =
+        vaultData && vaultData.length > token0BalanceIndex
+          ? vaultData[token0BalanceIndex]
+          : undefined;
+      const token1BalanceIndex = chainId === ChainId.MANTA ? 15 : 14;
+      const token1Balance =
+        vaultData && vaultData.length > token1BalanceIndex
+          ? vaultData[token1BalanceIndex]
+          : undefined;
+      const vaultCreatorIndex = chainId === ChainId.MANTA ? 16 : 15;
+      const vaultCreator =
+        vaultData && vaultData.length > vaultCreatorIndex
+          ? vaultData[vaultCreatorIndex]
+          : undefined;
 
-    const vaultItem = vaults?.find((item) => item.address === vaultAddress);
-    const slot0 = slot0Items.find(
-      (item) => vaultItem && item.poolAddress === vaultItem.poolAddress,
+      const vaultItem = vaults?.find((item) => item.address === vaultAddress);
+      const slot0 = slot0Items.find(
+        (item) => vaultItem && item.poolAddress === vaultItem.poolAddress,
+      );
+
+      const vaultPosition = vaultPositions[index];
+
+      return {
+        ...slot0,
+        address: vaultAddress,
+        state:
+          vaultRegistryData && vaultRegistryData.length > 0
+            ? Number(vaultRegistryData[0])
+            : undefined,
+        strategyName: vaultItem?.strategyName,
+        apr: vaultItem?.apr,
+        vaultType,
+        token0,
+        token1,
+        vaultName,
+        vaultSymbol,
+        vaultDecimals,
+        token0Name,
+        token0Symbol,
+        token0Decimals,
+        token1Name,
+        token1Symbol,
+        token1Decimals,
+        feeTier,
+        totalLPTokensIssued,
+        token0Balance,
+        token1Balance,
+        vaultCreator,
+        lowerTick:
+          vaultPosition &&
+          vaultPosition.lowerTicks &&
+          vaultPosition.lowerTicks.length > 0
+            ? Math.min(
+                ...vaultPosition.lowerTicks.map((tick: any) => Number(tick)),
+              )
+            : undefined,
+        upperTick:
+          vaultPosition &&
+          vaultPosition.upperTicks &&
+          vaultPosition.upperTicks.length > 0
+            ? Math.max(
+                ...vaultPosition.upperTicks.map((tick: any) => Number(tick)),
+              )
+            : undefined,
+      };
+    })
+    .filter(
+      (vaults) =>
+        vaults.lowerTick !== undefined && vaults.upperTick !== undefined,
     );
-
-    const vaultPosition = vaultPositions[index];
-
-    return {
-      ...slot0,
-      address: vaultAddress,
-      state:
-        vaultRegistryData && vaultRegistryData.length > 0
-          ? Number(vaultRegistryData[0])
-          : undefined,
-      strategyName: vaultItem?.strategyName,
-      apr: vaultItem?.apr,
-      vaultType,
-      token0,
-      token1,
-      vaultName,
-      vaultSymbol,
-      vaultDecimals,
-      token0Name,
-      token0Symbol,
-      token0Decimals,
-      token1Name,
-      token1Symbol,
-      token1Decimals,
-      feeTier,
-      totalLPTokensIssued,
-      token0Balance,
-      token1Balance,
-      vaultCreator,
-      lowerTick:
-        vaultPosition &&
-        vaultPosition.lowerTicks &&
-        vaultPosition.lowerTicks.length > 0
-          ? Math.min(
-              ...vaultPosition.lowerTicks.map((tick: any) => Number(tick)),
-            )
-          : undefined,
-      upperTick:
-        vaultPosition &&
-        vaultPosition.upperTicks &&
-        vaultPosition.upperTicks.length > 0
-          ? Math.max(
-              ...vaultPosition.upperTicks.map((tick: any) => Number(tick)),
-            )
-          : undefined,
-    };
-  });
-
   return { loading: isLoading, data: vaultDetails };
 };
 

--- a/src/pages/PoolsPage/v3/SupplyLiquidityV3/containers/SelectRange/index.tsx
+++ b/src/pages/PoolsPage/v3/SupplyLiquidityV3/containers/SelectRange/index.tsx
@@ -521,15 +521,15 @@ export function SelectRange({
         )
       : 0;
 
+  const steerVaultByPresetRange = steerVaultsForPair.find(
+    (item) =>
+      presetRange &&
+      presetRange.address &&
+      item.address.toLowerCase() === presetRange.address.toLowerCase(),
+  );
   const steerVault =
-    steerVaultsForPair.find(
-      (item) =>
-        presetRange &&
-        presetRange.address &&
-        item.address.toLowerCase() === presetRange.address.toLowerCase(),
-    ) ?? steerVaultsForPair
-      ? steerVaultsForPair[0]
-      : undefined;
+    steerVaultByPresetRange ??
+    (steerVaultsForPair.length > 0 ? steerVaultsForPair[0] : undefined);
 
   const { data: unipilotFarmData } = useUnipilotFarmData(
     unipilotVaultsForPair.map((pair) => pair.id),


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ac3c9913-2257-4545-9d18-a60ab59d39d4)

There are 4 vaults available for the selected pool (QuickNew + POL):

Pool Address: 0x9f1a8caf3c8e94e43aa64922d67dff4dc3e88a42
Vault 1 Address: 0x8b7dc6bb6e3d8fc3edd349403fab787ed6ed8003
Vault 2 Address: 0x9159ad3aedd8ce0e7f4ee7e817737c7fc80d2cf0
Vault 3 Address: 0xa92700fd49cc339faa88d53d2cf58c0f1b429446
Vault 4 Address: 0xf626514a3b5b7670e5d3cb2b6533e5eb4b3a9e9c
Vaults 1, 2, and 3 contain invalid addresses, while Vault 4 is valid.

As a result, the 3 invalid vaults showed "Out of Range" errors. When the setting is changed to "Narrow," the vault APR is displayed correctly (greater than 0).

This PR fixed an issue where, even after selecting "Narrow," the APR for Steer's vault was not shown. This happened because the contracts for Vaults 1, 2, and 3 are invalid, so the tick amounts were set to undefined.

Added code to hide the invalid Steer vaults to resolve this issue.