### PR TITLE
Fix min price to max price

### DIFF
--- a/src/components/v3/IncreaseLiquidityV3/index.tsx
+++ b/src/components/v3/IncreaseLiquidityV3/index.tsx
@@ -483,7 +483,7 @@ export default function IncreaseLiquidityV3({
             className='v3-increase-liquidity-price-wrapper'
             width={priceLower ? '49%' : '100%'}
           >
-            <p>{t('minPrice')}</p>
+            <p>{t('maxPrice')}</p>
             <h6>{formatTickPrice(priceUpper, ticksAtLimit, Bound.UPPER)}</h6>
             <p>
               {currencyQuote?.symbol} {t('per')} {currencyBase?.symbol}


### PR DESCRIPTION
It should say Max price on the right - not both min
![image](https://github.com/user-attachments/assets/501fa76a-02c9-4bf6-ac2e-cea321d224f9)
