### PR TITLE
Hotfix/analytics page UI bug

### DIFF
--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Box,
   Table,
@@ -72,6 +72,10 @@ const DataTable: React.FC<DataTableProps<any>> = ({
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(rowPerPage);
   const count = size || data.length;
+
+  useEffect(() => {
+    setPage(0);
+  }, [data]);
 
   const handleRequestSort = (
     event: React.MouseEvent<unknown>,

--- a/src/components/PairsTable/PairsTable.tsx
+++ b/src/components/PairsTable/PairsTable.tsx
@@ -5,7 +5,6 @@ import { ChainId, Token } from '@uniswap/sdk';
 import { getAddress } from '@ethersproject/address';
 import { DoubleCurrencyLogo, CustomTable } from 'components';
 import { GlobalConst } from 'constants/index';
-import { useBookmarkPairs } from 'state/application/hooks';
 import { ReactComponent as StarChecked } from 'assets/images/StarChecked.svg';
 import { ReactComponent as StarUnchecked } from 'assets/images/StarUnchecked.svg';
 import { useTranslation } from 'react-i18next';
@@ -14,6 +13,7 @@ import { useSelectedTokenList } from 'state/lists/hooks';
 import { useActiveWeb3React, useAnalyticsVersion } from 'hooks';
 import 'components/styles/AnalyticsTable.scss';
 import FarmingAPRTooltip from 'components/FarmingAPRTooltip';
+import { useLocalStorage } from '@orderly.network/hooks';
 
 interface PairsTableProps {
   data: any[];
@@ -113,11 +113,11 @@ const PairTable: React.FC<PairsTableProps> = ({
     ])
     .concat(version === 'v2' ? v2SpecificCells : v3SpecificCells);
 
-  const {
-    bookmarkPairs,
-    addBookmarkPair,
-    removeBookmarkPair,
-  } = useBookmarkPairs();
+  const [bookmarkPairs, setBookmarkPairs] = useLocalStorage<number[]>(
+    'bookmarkPairs',
+    [],
+  );
+
   const tokenMap = useSelectedTokenList();
   const mobileHTML = (pair: any, index: number) => {
     const token0 = getTokenFromAddress(pair.token0.id, chainIdToUse, tokenMap, [
@@ -165,9 +165,11 @@ const PairTable: React.FC<PairsTableProps> = ({
               onClick={() => {
                 const pairIndex = bookmarkPairs.indexOf(pair.id);
                 if (pairIndex === -1) {
-                  addBookmarkPair(pair.id);
+                  setBookmarkPairs([...bookmarkPairs, pair.id]);
                 } else {
-                  removeBookmarkPair(pair.id);
+                  setBookmarkPairs(
+                    bookmarkPairs.filter((item: number) => item !== pair.id),
+                  );
                 }
               }}
             >
@@ -375,9 +377,11 @@ const PairTable: React.FC<PairsTableProps> = ({
                 onClick={() => {
                   const pairIndex = bookmarkPairs.indexOf(pair.id);
                   if (pairIndex === -1) {
-                    addBookmarkPair(pair.id);
+                    setBookmarkPairs([...bookmarkPairs, pair.id]);
                   } else {
-                    removeBookmarkPair(pair.id);
+                    setBookmarkPairs(
+                      bookmarkPairs.filter((item: number) => item !== pair.id),
+                    );
                   }
                 }}
               >

--- a/src/components/TokensTable/TokensTable.tsx
+++ b/src/components/TokensTable/TokensTable.tsx
@@ -11,13 +11,14 @@ import {
   getPriceClass,
   getTokenFromAddress,
 } from 'utils';
-import { useBookmarkTokens, useIsV2 } from 'state/application/hooks';
+import { useIsV2 } from 'state/application/hooks';
 import { ReactComponent as StarChecked } from 'assets/images/StarChecked.svg';
 import { ReactComponent as StarUnchecked } from 'assets/images/StarUnchecked.svg';
 import 'components/styles/AnalyticsTable.scss';
 import { useTranslation } from 'react-i18next';
 import { useSelectedTokenList } from 'state/lists/hooks';
 import { useActiveWeb3React } from 'hooks';
+import { useLocalStorage } from '@orderly.network/hooks';
 
 interface TokensTableProps {
   data: any[];
@@ -36,6 +37,11 @@ const TokensTable: React.FC<TokensTableProps> = ({
   const tokenMap = useSelectedTokenList();
   const { isV2 } = useIsV2();
   const version = useMemo(() => `${isV2 ? `v2` : 'v3'}`, [isV2]);
+
+  const [favoriteTokens, setFavoriteTokens] = useLocalStorage<number[]>(
+    'favoriteAnalyticsTokens',
+    [],
+  );
 
   const tokenHeadCells = [
     {
@@ -70,11 +76,6 @@ const TokensTable: React.FC<TokensTableProps> = ({
       sortKey: (item: any) => item.totalLiquidityUSD,
     },
   ];
-  const {
-    bookmarkTokens,
-    addBookmarkToken,
-    removeBookmarkToken,
-  } = useBookmarkTokens();
   const mobileHTML = (token: any, index: number) => {
     const tokenCurrency = getTokenFromAddress(
       token.id,
@@ -98,15 +99,17 @@ const TokensTable: React.FC<TokensTableProps> = ({
             display='flex'
             mr={1}
             onClick={() => {
-              const tokenIndex = bookmarkTokens.indexOf(token.id);
+              const tokenIndex = favoriteTokens.indexOf(token.id);
               if (tokenIndex === -1) {
-                addBookmarkToken(token.id);
+                setFavoriteTokens([...favoriteTokens, token.id]);
               } else {
-                removeBookmarkToken(token.id);
+                setFavoriteTokens(
+                  favoriteTokens.filter((item: number) => item !== token.id),
+                );
               }
             }}
           >
-            {bookmarkTokens.indexOf(token.id) > -1 ? (
+            {favoriteTokens.indexOf(token.id) > -1 ? (
               <StarChecked />
             ) : (
               <StarUnchecked />
@@ -175,15 +178,17 @@ const TokensTable: React.FC<TokensTableProps> = ({
               display='flex'
               mr={1}
               onClick={() => {
-                const tokenIndex = bookmarkTokens.indexOf(token.id);
+                const tokenIndex = favoriteTokens.indexOf(token.id);
                 if (tokenIndex === -1) {
-                  addBookmarkToken(token.id);
+                  setFavoriteTokens([...favoriteTokens, token.id]);
                 } else {
-                  removeBookmarkToken(token.id);
+                  setFavoriteTokens(
+                    favoriteTokens.filter((item: number) => item !== token.id),
+                  );
                 }
               }}
             >
-              {bookmarkTokens.indexOf(token.id) > -1 ? (
+              {favoriteTokens.indexOf(token.id) > -1 ? (
                 <StarChecked />
               ) : (
                 <StarUnchecked />

--- a/src/pages/AnalyticsTokenDetails/AnalyticsTokenDetails.tsx
+++ b/src/pages/AnalyticsTokenDetails/AnalyticsTokenDetails.tsx
@@ -13,7 +13,7 @@ import {
 } from 'utils';
 import { useActiveWeb3React, useAnalyticsVersion } from 'hooks';
 import { CurrencyLogo, PairTable, TransactionsTable } from 'components';
-import { useBookmarkTokens, useIsV2 } from 'state/application/hooks';
+import { useIsV2 } from 'state/application/hooks';
 import { ReactComponent as StarChecked } from 'assets/images/StarChecked.svg';
 import { ReactComponent as StarUnchecked } from 'assets/images/StarUnchecked.svg';
 import { GlobalConst, TxnType } from 'constants/index';
@@ -39,11 +39,6 @@ const AnalyticsTokenDetails: React.FC = () => {
     [],
   );
 
-  // const {
-  //   bookmarkTokens,
-  //   addBookmarkToken,
-  //   removeBookmarkToken,
-  // } = useBookmarkTokens();
   const config = getConfig(chainId);
   const v3 = config['v3'];
   const v2 = config['v2'];

--- a/src/pages/AnalyticsTokenDetails/AnalyticsTokenDetails.tsx
+++ b/src/pages/AnalyticsTokenDetails/AnalyticsTokenDetails.tsx
@@ -24,6 +24,7 @@ import { useSelectedTokenList } from 'state/lists/hooks';
 import { getAddress } from 'ethers/lib/utils';
 import { getConfig } from 'config/index';
 import { useAnalyticsTokenDetails } from 'hooks/useFetchAnalyticsData';
+import { useLocalStorage } from '@orderly.network/hooks';
 
 const AnalyticsTokenDetails: React.FC = () => {
   const { t } = useTranslation();
@@ -33,11 +34,16 @@ const AnalyticsTokenDetails: React.FC = () => {
   const { chainId } = useActiveWeb3React();
   const tokenMap = useSelectedTokenList();
 
-  const {
-    bookmarkTokens,
-    addBookmarkToken,
-    removeBookmarkToken,
-  } = useBookmarkTokens();
+  const [favoriteTokens, setFavoriteTokens] = useLocalStorage<number[]>(
+    'favoriteAnalyticsTokens',
+    [],
+  );
+
+  // const {
+  //   bookmarkTokens,
+  //   addBookmarkToken,
+  //   removeBookmarkToken,
+  // } = useBookmarkTokens();
   const config = getConfig(chainId);
   const v3 = config['v3'];
   const v2 = config['v2'];
@@ -299,13 +305,21 @@ const AnalyticsTokenDetails: React.FC = () => {
                     <p className='heading1'>{data.token.name} </p>
                     <p className='heading2'>({data.token.symbol})</p>
                   </Box>
-                  {bookmarkTokens.includes(data.token.id) ? (
+                  {favoriteTokens.includes(data.token.id) ? (
                     <StarChecked
-                      onClick={() => removeBookmarkToken(data.token.id)}
+                      onClick={() =>
+                        setFavoriteTokens(
+                          favoriteTokens.filter(
+                            (item: number) => item !== data.token.id,
+                          ),
+                        )
+                      }
                     />
                   ) : (
                     <StarUnchecked
-                      onClick={() => addBookmarkToken(data.token.id)}
+                      onClick={() =>
+                        setFavoriteTokens([...favoriteTokens, data.token.id])
+                      }
                     />
                   )}
                 </Box>

--- a/src/state/application/hooks.ts
+++ b/src/state/application/hooks.ts
@@ -126,42 +126,6 @@ export function useTokenDetails(): {
   return { tokenDetails, updateTokenDetails: _updateTokenDetails };
 }
 
-export function useBookmarkTokens(): {
-  bookmarkTokens: string[];
-  addBookmarkToken: (data: string) => void;
-  removeBookmarkToken: (data: string) => void;
-  updateBookmarkTokens: (data: string[]) => void;
-} {
-  const bookmarkedTokens = useSelector(
-    (state: AppState) => state.application.bookmarkedTokens,
-  );
-  const dispatch = useDispatch();
-  const _addBookmarkToken = useCallback(
-    (token: string) => {
-      dispatch(addBookMarkToken(token));
-    },
-    [dispatch],
-  );
-  const _removeBookmarkToken = useCallback(
-    (token: string) => {
-      dispatch(removeBookmarkToken(token));
-    },
-    [dispatch],
-  );
-  const _updateBookmarkTokens = useCallback(
-    (tokens: string[]) => {
-      dispatch(updateBookmarkTokens(tokens));
-    },
-    [dispatch],
-  );
-  return {
-    bookmarkTokens: bookmarkedTokens,
-    addBookmarkToken: _addBookmarkToken,
-    removeBookmarkToken: _removeBookmarkToken,
-    updateBookmarkTokens: _updateBookmarkTokens,
-  };
-}
-
 export function useBookmarkPairs(): {
   bookmarkPairs: string[];
   addBookmarkPair: (data: string) => void;

--- a/src/state/application/hooks.ts
+++ b/src/state/application/hooks.ts
@@ -126,42 +126,6 @@ export function useTokenDetails(): {
   return { tokenDetails, updateTokenDetails: _updateTokenDetails };
 }
 
-export function useBookmarkPairs(): {
-  bookmarkPairs: string[];
-  addBookmarkPair: (data: string) => void;
-  removeBookmarkPair: (data: string) => void;
-  updateBookmarkPairs: (data: string[]) => void;
-} {
-  const bookmarkedPairs = useSelector(
-    (state: AppState) => state.application.bookmarkedPairs,
-  );
-  const dispatch = useDispatch();
-  const _addBookmarkPair = useCallback(
-    (pair: string) => {
-      dispatch(addBookMarkPair(pair));
-    },
-    [dispatch],
-  );
-  const _removeBookmarkPair = useCallback(
-    (pair: string) => {
-      dispatch(removeBookmarkPair(pair));
-    },
-    [dispatch],
-  );
-  const _updateBookmarkPairs = useCallback(
-    (pairs: string[]) => {
-      dispatch(updateBookmarkTokens(pairs));
-    },
-    [dispatch],
-  );
-  return {
-    bookmarkPairs: bookmarkedPairs,
-    addBookmarkPair: _addBookmarkPair,
-    removeBookmarkPair: _removeBookmarkPair,
-    updateBookmarkPairs: _updateBookmarkPairs,
-  };
-}
-
 export function useIsV2(): {
   isV2: boolean | undefined;
   updateIsV2: (isV2: boolean) => void;


### PR DESCRIPTION
- Issues
Issue1 - In analytics tokens and pairs page, favorites are removed on page reloading
Issue2 - In analytics pairs page, favorites selection is broken 
Issue3 - When selecting the `All`, `Favorites`, `Trending` tab, table page isn't updated in analytics tokens page.
If the user select page 3 on All tab and go to `Favorites` tab,  the page 3 is selected even if there is a favorite item.
so the user can't see any favorites.

- All issues are fixed in this PR.
Issue1 and Issue2 are fixed by using local storage instead of redux store.
Issue 3 is fixed.
