### PR TITLE
Fix: Liquidity Added Twice When Vault is Selected as Gamma

### DIFF
--- a/src/pages/PoolsPage/v3/SupplyLiquidityV3/containers/AddLiquidityButton/index.tsx
+++ b/src/pages/PoolsPage/v3/SupplyLiquidityV3/containers/AddLiquidityButton/index.tsx
@@ -416,8 +416,7 @@ export function AddLiquidityButton({
             : t('errorInTx'),
         );
       }
-    }
-    if (
+    } else if (
       mintInfo.liquidityRangeType ===
       GlobalConst.v3LiquidityRangeType.STEER_RANGE
     ) {


### PR DESCRIPTION
### Description

When a user selects the Gamma vault and adds liquidity, the system performs two separate liquidity additions:

1. The first transaction adds liquidity to the Gamma vault.
2. The second transaction incorrectly adds liquidity to Quickswap instead of Gamma.

### Steps to Reproduce

1. Navigate to the pool page.
2. Select the Gamma vault as the target liquidity option.
3. Add liquidity and confirm the transaction.
4. Observe that liquidity is first added to the Gamma vault.
5. Notice that a second liquidity addition occurs, this time to Quickswap.

### Expected Behavior

- Liquidity should be added **only once** to the selected Gamma vault.
- No unexpected second transaction should occur.

### Actual Behavior

- Liquidity is first added correctly to the Gamma vault.
- A second transaction occurs, mistakenly adding liquidity to Quickswap.

### Possible Causes

- Incorrect transaction flow triggering two separate liquidity additions.
- UI or state issue causing a secondary unintended transaction.

### Proposed Fix

- Ensure that liquidity is added only once to the selected vault.
- Verify the transaction flow logic to prevent redundant transactions.