### PR TITLE
Ape.bond API url updated and fixed missing close buttons in bond modals

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -61,7 +61,7 @@ import {
 import { FeeAmount } from 'v3lib/utils';
 import { BondToken } from 'types/bond';
 
-export const bondAPIV2BaseURL = 'https://api-v2.apeswap.finance';
+export const bondAPIV2BaseURL = 'https://api.ape.bond';
 export const CEX_BILL_ADDRESS = '0x6D7637683eaD28F775F56506602191fdE417fF60';
 
 export const AVERAGE_L1_BLOCK_TIME = 12000;

--- a/src/pages/BondsPage/TransferBondModal.tsx
+++ b/src/pages/BondsPage/TransferBondModal.tsx
@@ -45,7 +45,7 @@ const TransferBillModal: React.FC<TransferBillModalProps> = ({
       <Box p='20px'>
         <Box className='flex justify-between border-bottom' pb='16px'>
           <h5>{t('tranferBond')}</h5>
-          <Close />
+          <Close className='cursor-pointer' onClick={onClose} />
         </Box>
         <Box className='flex' mt='20px'>
           <p>{t('transferring')}: </p>

--- a/src/pages/BondsPage/UserBondModalView.tsx
+++ b/src/pages/BondsPage/UserBondModalView.tsx
@@ -18,6 +18,7 @@ import { formatUnits } from 'ethers/lib/utils';
 import { formatNumber } from 'utils';
 import { useCurrency, useCurrencyFromSymbol } from 'hooks/Tokens';
 import { CurrencyLogo, DoubleCurrencyLogo } from 'components';
+import { Close } from '@material-ui/icons';
 
 interface BondModalProps {
   onDismiss?: () => void;
@@ -81,6 +82,9 @@ const UserBondModalView: React.FC<BondModalProps> = ({
           chainId={chainId}
         />
       )}
+      <Box mb={1} className='flex justify-end'>
+        <Close className='cursor-pointer' onClick={onDismiss} />
+      </Box>
       <Grid container spacing={2}>
         <Grid item xs={12} sm={12} md={6}>
           <Box className='flex'>


### PR DESCRIPTION
### Description

Two UI issues have been identified in the **User Bond View Modal** and **Transfer Modal**:

1. **No Close Button:**
- Both modals lack a close button, forcing users to click outside the modal to exit.
- This can cause usability issues, especially on smaller screens or mobile devices.
2. **Missing Attributes in User Bond View Modal:**
- Important bond-related attributes are missing in the **User Bond View Modal**, making it difficult for users to view relevant details.

### Steps to Reproduce

1. Open the **User Bond View Modal** or **Transfer Modal**.
2. Observe that there is **no close button** present in either modal.
3. Check the **User Bond View Modal** and note the missing bond-related attributes.

### Expected Behavior

- Both modals should include a **close button** for better user experience.
- The **User Bond View Modal** should display all relevant bond attributes to provide complete information to the user.

### Proposed Fix

- Add a **close button** to both modals for easy dismissal.
- Ensure that **Apebond API** url is correct or updated.

### Screenshots

- #### User Bond View Modal

<img width="872" alt="Image" src="https://github.com/user-attachments/assets/da13d667-9cb4-4c38-b1ec-712e290eb99f" />

- #### Transfer Modal

<img width="590" alt="Image" src="https://github.com/user-attachments/assets/274e54cf-3a9c-4d57-83d0-5c033adf0686" />

### Fixed Result

<img width="876" alt="image" src="https://github.com/user-attachments/assets/5bc66183-7f44-432c-bc1a-58d4e0b88ca2" />