### PR TITLE
Fix favourite token issue across networks

### DIFF
--- a/src/components/CurrencySearchModal/CurrencySearch.tsx
+++ b/src/components/CurrencySearchModal/CurrencySearch.tsx
@@ -56,28 +56,41 @@ const CurrencySearch: React.FC<CurrencySearchProps> = ({
   onDismiss,
   isOpen,
 }) => {
-  const userAddedTokens = useUserAddedTokens();
+  const { account, chainId } = useActiveWeb3React();
+  const chainIdToUse = chainId ? chainId : ChainId.MATIC;
+  const [favoriteCurrenciesRaw, setFavoriteCurrencies] = useLocalStorage<{
+    [chainId: number]: Currency[];
+  }>('favoriteCurrencies', {});
 
-  const [favoriteCurrencies, setFavoriteCurrencies] = useLocalStorage<
-    Currency[]
-  >('favoriteCurrencies', []);
+  const favoriteCurrencies = useMemo(() => {
+    return favoriteCurrenciesRaw[chainIdToUse] || [];
+  }, [favoriteCurrenciesRaw, chainIdToUse]);
 
-  // const [favoriteCurrencies, setFavoriteCurrencies] = useState<Currency[]>([]);
   const handleChangeFavorite = (currency: Currency, checked: boolean) => {
+    const newChainIdFavoriteCurrenciesRaw =
+      favoriteCurrenciesRaw[chainId] ?? [];
     if (checked) {
-      setFavoriteCurrencies([...favoriteCurrencies, currency]);
+      const newFavoriteCurrenciesRaw = {
+        ...favoriteCurrenciesRaw,
+        [chainId]: [...newChainIdFavoriteCurrenciesRaw, currency],
+      };
+      setFavoriteCurrencies(newFavoriteCurrenciesRaw);
     } else {
-      setFavoriteCurrencies(
-        favoriteCurrencies.filter(
-          (item: Currency) => item.symbol !== currency.symbol,
-        ),
-      );
+      const newFavoriteCurrenciesRaw = {
+        ...favoriteCurrenciesRaw,
+        [chainId]: [
+          ...newChainIdFavoriteCurrenciesRaw.filter(
+            (item: Currency) => item.symbol !== currency.symbol,
+          ),
+        ],
+      };
+      setFavoriteCurrencies(newFavoriteCurrenciesRaw);
     }
   };
   const { t } = useTranslation();
-  const { account, chainId } = useActiveWeb3React();
+
   const dispatch = useDispatch<AppDispatch>();
-  const chainIdToUse = chainId ? chainId : ChainId.MATIC;
+
   const nativeCurrency = ETHER[chainIdToUse];
 
   const handleInput = useCallback((input: string) => {


### PR DESCRIPTION
# Description:
When adding tokens as favorites, the following issues occur:

1.  Favorite tokens are shared across all networks instead of being network-specific
2. Duplicate tokens are being stored in local storage when adding them multiple times

## How to reproduce:
1. Connect wallet to Polygon network
2. Add a token as favorite (e.g. 0xd3ac016b1b8c80eeadde4d186a9138c9324e4189)
3. Switch to another network (e.g. Soneium)
4. The same token appears as favorite even though it's a different network
5. Check local storage and observe duplicate entries