### PR TITLE
Hotfix: Incorrect logo placement for QUICK(OLD) and QUICK(NEW) in convert page

### DIFF
--- a/src/pages/ConvertQUICKPage/ConvertQUICKPage.tsx
+++ b/src/pages/ConvertQUICKPage/ConvertQUICKPage.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { TransactionResponse } from '@ethersproject/providers';
 import { Box, Button, CircularProgress } from '@material-ui/core';
 import { Trans, useTranslation } from 'react-i18next';
-import QUICKIcon from 'assets/images/quickIcon.svg';
-import { ReactComponent as QUICKV2Icon } from 'assets/images/QUICKV2.svg';
+import QUICKIcon from 'assets/images/QUICKV2.svg';
+import QUICKV2Icon from 'assets/images/quickIcon.svg';
 import { ArrowForward, ArrowDownward } from '@material-ui/icons';
 import {
   NumericalInput,
@@ -174,7 +174,7 @@ const ConvertQUICKPage: React.FC<ConvertQUICKPageProps> = ({ isWidget }) => {
             <ArrowForward />
           </Box>
           <Box className='iconWrapper'>
-            <QUICKV2Icon />
+            <img src={QUICKV2Icon} alt='QUICK' />
           </Box>
           <p className='weight-600'>QUICK(NEW)</p>
         </Box>


### PR DESCRIPTION
Issue fixed!

### Description

On the **Convert Page**, the logos for **Quick (Old)** and **Quick (New)** are swapped. The **Quick (Old)** logo is being displayed where the **Quick (New)** logo should be, and vice versa. This may cause confusion for users performing conversions.

### Steps to Reproduce

1. Navigate to the Convert Page.
2. Observe the logos assigned to **Quick (Old)** and **Quick (New)**.
3. Notice that they are incorrectly placed.

### Expected Behavior

- The **Quick (Old)** logo should be displayed next to **Quick (Old)**.
- The **Quick (New)** logo should be displayed next to **Quick (New)**.

### Actual Behavior

- The logos are swapped, leading to potential user confusion.

### Screenshots

<img width="412" alt="Image" src="https://github.com/user-attachments/assets/6baf9de1-0708-4025-8510-c97df2c836d9" />