### PR TITLE
Fix: Sort by functionality not properly working in my rewards in farms page

### DIFF
--- a/src/pages/FarmPage/V3/MyRewardFarms.tsx
+++ b/src/pages/FarmPage/V3/MyRewardFarms.tsx
@@ -226,11 +226,11 @@ const MyRewardFarms: React.FC<Props> = ({
       if (sortBy === GlobalConst.utils.v3FarmSortBy.apr) {
         return farm1.apr > farm2.apr ? sortMultiplier : -1 * sortMultiplier;
       }
-      // if (sortBy === GlobalConst.utils.v3FarmSortBy.rewards) {
-      //   return farm1.dailyRewardUSD > farm2.dailyRewardUSD
-      //     ? sortMultiplier
-      //     : -1 * sortMultiplier;
-      // }
+      if (sortBy === GlobalConst.utils.v3FarmSortBy.rewards) {
+        return farm1.dailyRewardUSD > farm2.dailyRewardUSD
+          ? sortMultiplier
+          : -1 * sortMultiplier;
+      }
       return 1;
     });
 
@@ -333,6 +333,26 @@ const MyRewardFarms: React.FC<Props> = ({
     );
   }, [farmType.link, selectedFarms]);
 
+  const sortedSelectedFarms = useMemo(() => {
+    return [...filteredSelectedFarms].sort((a: any, b: any) => {
+      if (sortBy === GlobalConst.utils.v3FarmSortBy.pool) {
+        return a.title > b.title ? sortMultiplier : -1 * sortMultiplier;
+      }
+      if (sortBy === GlobalConst.utils.v3FarmSortBy.tvl) {
+        return a.almTVL > b.almTVL ? sortMultiplier : -1 * sortMultiplier;
+      }
+      if (sortBy === GlobalConst.utils.v3FarmSortBy.apr) {
+        return a.almAPR + a.poolAPR > b.almAPR + b.poolAPR
+          ? sortMultiplier
+          : -1 * sortMultiplier;
+      }
+      if (sortBy === GlobalConst.utils.v3FarmSortBy.rewards) {
+        return a.rewards > b.rewards ? sortMultiplier : -1 * sortMultiplier;
+      }
+      return 1;
+    });
+  }, [filteredSelectedFarms]);
+
   return (
     <>
       <Box pt={2}>
@@ -355,8 +375,8 @@ const MyRewardFarms: React.FC<Props> = ({
           </Box>
         ) : (
           <Box px={2}>
-            {filteredSelectedFarms.length > 0 ? (
-              filteredSelectedFarms.map((farm, ind) => (
+            {sortedSelectedFarms.length > 0 ? (
+              sortedSelectedFarms.map((farm, ind) => (
                 <Box key={ind} pb={2}>
                   <MerklPairFarmCard farm={farm} />
                 </Box>


### PR DESCRIPTION
Fix the following issue:
##

### Description

The **"Sort By"** functionality in the **My Rewards** section on the **Farms page** is not working as expected. When selecting different sorting options, the rewards list does not update correctly.

### Steps to Reproduce

1. Navigate to the **Farms page**.
2. Go to the **My Rewards** section.
3. Click on the **Sort By** dropdown and select different sorting options (e.g., APR).
4. Observe that the sorting does not update properly.

### Expected Behavior

- The rewards list should be correctly sorted based on the selected Sort By option.
- Sorting should work consistently for all available options.

### Actual Behavior

- Sorting follows an incorrect order.

### Proposed Fix

- Verify the sorting logic and ensure it applies the correct ordering.

### Screenshots

<img width="987" alt="Image" src="https://github.com/user-attachments/assets/ef09910b-7fc8-445f-84e2-a23f79766b06" />