### PR TITLE
Fix a bug on currency modal

### DIFF
--- a/src/components/CurrencySearchModal/CommonBases.tsx
+++ b/src/components/CurrencySearchModal/CommonBases.tsx
@@ -61,7 +61,9 @@ const CommonBases: React.FC<CommonBasesProps> = ({
         </Box>
 
         {(chainId ? SUGGESTED_BASES[chainId] ?? [] : [])
-          .filter((item) => !currencies.some((c) => c.symbol === item.symbol))
+          .filter(
+            (item) => item && !currencies.some((c) => c.symbol === item.symbol),
+          )
           .map((token: Token) => {
             const selected = Boolean(
               selectedCurrency && currencyEquals(selectedCurrency, token),


### PR DESCRIPTION
- Reproduce Issue
1. Select Soneium network
2. Goto pools page and select double sided 
3. Click "Select a token"
4. Click favorite tabs. 
5. It displays blank screen.
6. This issue is produced on dev2 and master branch
<img width="670" alt="image" src="https://github.com/user-attachments/assets/aae9daa8-f52a-4bb7-be4e-135b428120d7" />


This PR is fixed this issue.