### PR TITLE
Fix: "Sort by" functionality not working in pool view in farms page

### DIFF
--- a/src/pages/FarmPage/V3/AllMerklFarms.tsx
+++ b/src/pages/FarmPage/V3/AllMerklFarms.tsx
@@ -333,6 +333,30 @@ const AllMerklFarms: React.FC<Props> = ({
     );
   }, [farmType.link, selectedFarms, staked]);
 
+  const sortedSelectedFarms = useMemo(() => {
+    return filteredSelectedFarms.sort((farm1, farm2) => {
+      if (selectedSort === GlobalConst.utils.v3FarmSortBy.pool) {
+        return farm1.title > farm2.title ? sortMultiplier : -1 * sortMultiplier;
+      }
+      if (selectedSort === GlobalConst.utils.v3FarmSortBy.tvl) {
+        return farm1.almTVL > farm2.almTVL
+          ? sortMultiplier
+          : -1 * sortMultiplier;
+      }
+      if (selectedSort === GlobalConst.utils.v3FarmSortBy.apr) {
+        return farm1.almAPR + farm1.poolAPR > farm2.almAPR + farm2.poolAPR
+          ? sortMultiplier
+          : -1 * sortMultiplier;
+      }
+      if (selectedSort === GlobalConst.utils.v3FarmSortBy.rewards) {
+        return farm1.rewards > farm2.rewards
+          ? sortMultiplier
+          : -1 * sortMultiplier;
+      }
+      return 1;
+    });
+  }, [filteredSelectedFarms, selectedSort, sortMultiplier]);
+
   return (
     <>
       {poolId && (
@@ -431,8 +455,8 @@ const AllMerklFarms: React.FC<Props> = ({
         ) : (
           <Box px={2}>
             {poolId ? (
-              filteredSelectedFarms.length > 0 ? (
-                filteredSelectedFarms.map((farm, ind) => (
+              sortedSelectedFarms.length > 0 ? (
+                sortedSelectedFarms.map((farm, ind) => (
                   <Box key={ind} pb={2}>
                     <MerklPairFarmCard farm={farm} />
                   </Box>


### PR DESCRIPTION
Fix the following issue:
##

### Description

The **"Sort By"** functionality is not working properly when viewing an individual pool in the Farms page. The available sorting options (Pool, TVL, APR, Rewards) do not update the list correctly, making it difficult for users to organize the data as needed.

### Steps to Reproduce

1. Navigate to the **Farms page**.
2. Select and view a **specific pool**.
3. Click on the **Sort By** dropdown and choose different sorting options (Pool, TVL, APR, Rewards).
4. Observe that the list does not update or reflect the correct sorting order.

### Expected Behavior

- The pool list should be sorted properly based on the selected option (Pool, TVL, APR, or Rewards).
- Sorting should dynamically update the displayed data.

### Actual Behavior

- Sorting does not update the list or follows an incorrect order.
- The displayed data remains unchanged despite selecting different sorting options.

### Proposed Fix

- Verify the sorting logic and ensure it applies the correct ordering.
- Debug any state management issues preventing the sorting from updating dynamically.
- Test sorting across different pools to confirm consistent behavior.

### Screenshots

https://github.com/user-attachments/assets/c2f674c1-5ffa-4c67-ad14-511940191322