### PR TITLE
Fix: Infinite loading when choosing Gamma vault in pools

### DIFF
--- a/src/pages/PoolsPage/v3/SupplyLiquidityV3/components/PresetRanges/index.tsx
+++ b/src/pages/PoolsPage/v3/SupplyLiquidityV3/components/PresetRanges/index.tsx
@@ -152,17 +152,14 @@ export function PresetRanges({
       gammaBaseUppers.length >= index &&
       gammaCurrentTicks.length >= index
     ) {
-      const gammaBaseLower = gammaBaseLowers[index];
-      const gammaCurrentTick = gammaCurrentTicks[index];
-      const gammaBaseUpper = gammaBaseUppers[index];
+      const gammaBaseLower = gammaBaseLowers[index] ?? 0;
+      const gammaCurrentTick = gammaCurrentTicks[index] ?? 0;
+      const gammaBaseUpper = gammaBaseUppers[index] ?? 0;
 
-      if (gammaBaseLower && gammaCurrentTick && gammaBaseUpper) {
-        const lowerValue = Math.pow(1.0001, gammaBaseLower - gammaCurrentTick);
-        const upperValue = Math.pow(1.0001, gammaBaseUpper - gammaCurrentTick);
+      const lowerValue = Math.pow(1.0001, gammaBaseLower - gammaCurrentTick);
+      const upperValue = Math.pow(1.0001, gammaBaseUpper - gammaCurrentTick);
 
-        return { min: lowerValue, max: upperValue };
-      }
-      return;
+      return { min: lowerValue, max: upperValue };
     }
     return;
   });


### PR DESCRIPTION
Fix the following issue:

##

### Description

When navigating through the **Farms page** and selecting a **stablecoin pool** with **USDC** as one of the tokens, an issue occurs when choosing **Gamma as the vault**. The APR value for Gamma changes to **0** and gets stuck in an **infinite loading state**.

### Steps to Reproduce

1. Go to the **Farms page**.
2. Select **Stablecoins** and choose a pool containing **USDC**.
3. Select a pool that uses **Gamma Pool Manager**.
4. Click the **Get LP** button to navigate to the **Pool page** with the selected token pair.
5. Stay with **Automatic Range** and select **Gamma** as the vault.
6. Observe that the **APR value for Gamma changes to 0** and starts **infinite loading**.

### Expected Behavior

- The **APR value** should load correctly for the selected **Gamma vault**.
- There should be **no infinite loading**—the data should be fetched and displayed properly.

### Actual Behavior

- The **APR value turns to 0** instead of displaying the correct percentage.
- The loading indicator keeps spinning indefinitely, preventing users from seeing the range.

### Proposed Fix

- Investigate why the **Gamma APR value is not loading correctly**.
- Ensure that the **API response for Gamma APR is correctly fetched and processed**.
- Implement proper **error handling and fallback behavior** if the APR data is unavailable.

### Screenshots

https://github.com/user-attachments/assets/d446f85f-b094-4baa-b145-b29368f8f2d8