### PR TITLE
Fix a bug to hide the range selection part on soneium network pools page.

### DIFF
--- a/src/pages/PoolsPage/v3/SupplyLiquidityV3/containers/SelectRange/index.tsx
+++ b/src/pages/PoolsPage/v3/SupplyLiquidityV3/containers/SelectRange/index.tsx
@@ -420,6 +420,44 @@ export function SelectRange({
     return vaults;
   }, [gammaPairExists, steerVaultExists, unipilotVaultExists]);
 
+  useEffect(() => {
+    if (loadingSteerVaults) {
+      return;
+    }
+    if (automaticEnabled) {
+      if (selectVaultEnabled) {
+        onChangeLiquidityRangeType('');
+      } else {
+        if (gammaPairExists) {
+          onChangeLiquidityRangeType(
+            GlobalConst.v3LiquidityRangeType.GAMMA_RANGE,
+          );
+        } else if (steerVaultExists) {
+          onChangeLiquidityRangeType(
+            GlobalConst.v3LiquidityRangeType.STEER_RANGE,
+          );
+        } else {
+          onChangeLiquidityRangeType(
+            GlobalConst.v3LiquidityRangeType.UNIPILOT_RANGE,
+          );
+        }
+      }
+    } else {
+      onChangeLiquidityRangeType(GlobalConst.v3LiquidityRangeType.MANUAL_RANGE);
+    }
+  }, [
+    gammaPairExists,
+    automaticEnabled,
+    onChangeLiquidityRangeType,
+    selectVaultEnabled,
+    steerVaultExists,
+    currencyA?.isNative,
+    currencyB?.isNative,
+    currencyAAddress,
+    currencyBAddress,
+    loadingSteerVaults,
+  ]);
+
   const handleSelectAutomatic = () => {
     if (selectVaultEnabled) {
       onChangeLiquidityRangeType('');


### PR DESCRIPTION
- Issue
In pools page, The range selection buttons is hidden on soneium network
<img width="540" alt="image" src="https://github.com/user-attachments/assets/ee4e60b4-5095-49a8-b398-71fe50303c89" />

- This PR is fixed this issue.
<img width="629" alt="image" src="https://github.com/user-attachments/assets/5bc2b489-577f-4753-a296-3d81212706d6" />
