### PR TITLE
Fix: Sorting functionality for active and ended farms on Dogechain

### DIFF
--- a/src/pages/FarmPage/V3/AllV3Farms.tsx
+++ b/src/pages/FarmPage/V3/AllV3Farms.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Box, useMediaQuery, useTheme } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
 import CustomTabSwitch from 'components/v3/CustomTabSwitch';
@@ -34,6 +34,7 @@ import { getConfig } from 'config/index';
 interface Props {
   searchValue: string;
   farmStatus: string;
+  sortValue: string;
 }
 
 export interface V3FarmPair {
@@ -46,7 +47,11 @@ export interface V3FarmPair {
   farms: V3Farm[];
 }
 
-const AllV3Farms: React.FC<Props> = ({ searchValue, farmStatus }) => {
+const AllV3Farms: React.FC<Props> = ({
+  searchValue,
+  farmStatus,
+  sortValue,
+}) => {
   const { t } = useTranslation();
   const { breakpoints } = useTheme();
   const { chainId } = useActiveWeb3React();
@@ -126,6 +131,10 @@ const AllV3Farms: React.FC<Props> = ({ searchValue, farmStatus }) => {
       },
     };
   });
+
+  useEffect(() => {
+    setSortBy(sortValue);
+  }, [sortValue]);
 
   const {
     data: allEternalFarms,

--- a/src/pages/FarmPage/V3/Farms.tsx
+++ b/src/pages/FarmPage/V3/Farms.tsx
@@ -284,7 +284,11 @@ export default function Farms() {
               sortValue={selectedSort}
             />
           ) : (
-            <AllV3Farms searchValue={searchValue} farmStatus={farmStatus} />
+            <AllV3Farms
+              searchValue={searchValue}
+              farmStatus={farmStatus}
+              sortValue={selectedSort}
+            />
           ))}
         {selectedFarmCategory.id === 2 && (
           <FarmingMyFarms search={searchValue} chainId={chainIdToUse} />


### PR DESCRIPTION
Fix the following issue:

##

### Description

When selecting **Dogechain** as the network in the **Farms page**, farms are categorized under **Active** and **Ended** statuses. The **Sort By** functionality does not work properly for these statuses.

Currently, there are **no active farms**, but there are **ended farms**. However, sorting does not work for the Ended farms, preventing users from organizing the list by different sorting options.

### Steps to Reproduce

1. Navigate to the **Farms page**.
2. Select **Dogechain** as the network.
3. Observe that no farms are listed under **Active** status.
4. Switch to **Ended** farms and attempt to use the **Sort By** dropdown.
5. Notice that the sorting does not update the list correctly.

### Expected Behavior

- The **Sort By** functionality should properly sort **Ended** farms based on the selected option.
- If Active farms are present in the future, sorting should function correctly for them as well.

### Actual Behavior

- Sorting does not work for Ended farms.
- No visible impact when selecting different sorting options.

### Proposed Fix

- Ensure the **sorting logic** applies correctly to **Ended** farms.
- Verify that sorting works dynamically when farms are listed under **Active** status in the future.
- Debug state management issues that might be preventing updates.

### Screenshots

<img width="986" alt="Image" src="https://github.com/user-attachments/assets/4f1c9e2b-27a1-47d4-b20e-34362291f061" />